### PR TITLE
Handle Q/A defaults in collection metadata

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,6 +45,11 @@ SUMM_NUM_ITEMS=5
 VERBOSE_MODE=True
 PROMPT_LANG=en
 
+## Feature flags
+#
+# Uncomment to detect question language with Spacy
+# FEATURE_QA_LANG_DETECT=True
+
 # Docker only vars
 API_PORT=8000
 API_VERSION=0.5

--- a/.env.sample
+++ b/.env.sample
@@ -1,32 +1,29 @@
 ## API conf vars
 OPENAI_API_KEY=#########
 
-# FOLLOW-UP question
-QA_FOLLOWUP_MODEL=text-davinci-003
-QA_FOLLOWUP_TEMPERATURE=0
+## QA vars
+QA_MODEL=gpt-3.5-turbo
+QA_TEMPERATURE=0
+QA_MAX_TOKENS=1000
+QA_FOLLOWUP_MODEL=gpt-3.5-turbo
 QA_FOLLOWUP_MAX_TOKENS=200
 QA_FOLLOWUP_SIM_THRESHOLD=0.735
 
-# Temp env var - uncomment to disable session conversation, avoiding chat history loading
+## Temp env var - uncomment to disable session conversation, avoiding chat history loading
 # QA_NO_CHAT_HISTORY=True
 
-# QA
-QA_COMPLETIONS_MODEL=gpt-3.5-turbo
-QA_TEMPERATURE=0
-QA_MAX_TOKENS=2000
-
 # Embedding
-# uncomment to use fake random embedding
+# Uncomment to use fake random embedding
 # FAKE_EMBEDDING=True
 
 # Access tokens secret - if missing no access token validity is checked
 # Generate it with: openssl rand -hex 32
 # TOKENS_SECRET=##########################
-# comma separated list of valid users - use double quotes!
+# Comma separated list of valid users - use double quotes!
 # TOKENS_USERS="brevia,gustavo"
 
 # Search
-# number of documents to return in a vector search
+# default number of documents to return in a vector search
 SEARCH_DOCS_NUM=4
 
 # Index creation

--- a/brevia/language.py
+++ b/brevia/language.py
@@ -20,7 +20,7 @@ class Detector():
             self.nlp = spacy.load('en_core_web_sm')
             self.nlp.add_pipe('language_detector')
 
-        except ImportError as exc:
+        except Exception as exc:
             raise ImportError(
                 "SpaCy `en_core_web_sm` not installed!"
             ) from exc

--- a/brevia/language.py
+++ b/brevia/language.py
@@ -1,4 +1,5 @@
 """Language detection utilities"""
+from os import environ
 import spacy
 from spacy.language import Language
 import langcodes
@@ -6,10 +7,13 @@ import langcodes
 
 class Detector():
     """Language detection class"""
-    nlp: Language
+    nlp: Language | None = None
 
     def __init__(self):
         """Init internal nlp"""
+        if not bool(environ.get('FEATURE_QA_LANG_DETECT')):
+            return
+
         try:
             import spacy_fastlang  # noqa: F401 pylint: disable=import-outside-toplevel
 
@@ -22,7 +26,12 @@ class Detector():
             ) from exc
 
     def detect(self, phrase: str) -> str:
-        """Detect language of generic phrase"""
+        """
+            Detect language of generic phrase, return an empty string
+            if Spacy has not been initialized
+        """
+        if not self.nlp:
+            return ''
         doc = self.nlp(phrase)
 
         return langcodes.Language.make(language=doc._.language).display_name()

--- a/brevia/prompts/qa/default.system.yaml
+++ b/brevia/prompts/qa/default.system.yaml
@@ -1,4 +1,5 @@
 _type: prompt
+template_format: "jinja2"
 input_variables:
     ["context", "lang"]
 template: |
@@ -9,8 +10,8 @@ template: |
 
     ##Context start##
 
-    {context}
+    {{ context }}
 
     ##Context end##
 
-    Answer in {lang}:
+    Answer in {% if lang|length %}{{ lang }}{% else %}the same language of the question{% endif %}

--- a/brevia/query.py
+++ b/brevia/query.py
@@ -106,12 +106,15 @@ def conversation_chain(
         Return conversation chain for Q/A with embdedded dataset knowledge
 
         collection: name of collection to questioning
-        docs_num: number of docs to retrieve to create context (default SEARCH_DOCS_NUM env var or '4')
+        docs_num: number of docs to retrieve to create context
+            (default 'SEARCH_DOCS_NUM' env var or '4')
         source_docs: flag to retrieve source docs in response (default True)
         distance_strategy_name: distance strategy to use (default 'cosine')
         streaming: activate streaming (default False),
-        answer_callbacks: callbacks to use in the final LLM answer to enable streaming (default empty list)
-        conversation_callbacks: callback to handle conversation results (default empty list)
+        answer_callbacks: callbacks to use in the final LLM answer to enable streaming
+            (default empty list)
+        conversation_callbacks: callback to handle conversation results
+            (default empty list)
 
         can implement "vectordbkwargs" into quest_dict:
             {

--- a/brevia/query.py
+++ b/brevia/query.py
@@ -122,7 +122,8 @@ def conversation_chain(
             }
     """
     if docs_num is None:
-        docs_num = int(collection.cmetadata.get('docs_num', environ.get('QA_MODEL')))
+        default_num = environ.get('SEARCH_DOCS_NUM', 4)
+        docs_num = int(collection.cmetadata.get('docs_num', default_num))
 
     docsearch = PGVector(
         connection_string=connection.connection_string(),

--- a/brevia/query.py
+++ b/brevia/query.py
@@ -106,12 +106,12 @@ def conversation_chain(
         Return conversation chain for Q/A with embdedded dataset knowledge
 
         collection: name of collection to questioning
-        source_docs: retrive source docs
-        docs_num: number of docs to retrieve to create context
-        distance_strategy_name: distance strategy to use
+        docs_num: number of docs to retrieve to create context (default SEARCH_DOCS_NUM env var or '4')
+        source_docs: flag to retrieve source docs in response (default True)
+        distance_strategy_name: distance strategy to use (default 'cosine')
         streaming: activate streaming (default False),
-        answer_callbacks: callbacks to use in the final LLM answer to enable streaming
-        conversation_callbacks: callback to handle conversation results
+        answer_callbacks: callbacks to use in the final LLM answer to enable streaming (default empty list)
+        conversation_callbacks: callback to handle conversation results (default empty list)
 
         can implement "vectordbkwargs" into quest_dict:
             {
@@ -119,7 +119,7 @@ def conversation_chain(
             }
     """
     if docs_num is None:
-        docs_num = int(environ.get('SEARCH_DOCS_NUM', 4))
+        docs_num = int(collection.cmetadata.get('docs_num', environ.get('QA_MODEL')))
 
     docsearch = PGVector(
         connection_string=connection.connection_string(),
@@ -129,13 +129,16 @@ def conversation_chain(
     )
 
     prompts = collection.cmetadata.get('prompts')
+    model_name = collection.cmetadata.get('model_name', environ.get('QA_MODEL'))
+    temperature = collection.cmetadata.get('temperature', environ.get('QA_TEMPERATURE'))
+    verbose = environ.get('VERBOSE_MODE', False)
 
     # LLM to rewrite follow-up question
     fup_llm = OpenAI(
-        model_name=environ.get('QA_FOLLOWUP_MODEL'),
-        temperature=float(environ.get('QA_FOLLOWUP_TEMPERATURE', 0)),
+        model_name=environ.get('QA_FOLLOWUP_MODEL', 'gpt-3.5-turbo'),
+        temperature=float(temperature),
         max_tokens=int(environ.get('QA_FOLLOWUP_MAX_TOKENS', 200)),
-        verbose=environ.get('VERBOSE_MODE', False),
+        verbose=verbose,
     )
 
     logging_handler = AsyncLoggingCallbackHandler()
@@ -143,19 +146,19 @@ def conversation_chain(
     question_generator = LLMChain(
         llm=fup_llm,
         prompt=load_condense_prompt(prompts),
-        verbose=environ.get('VERBOSE_MODE', False),
+        verbose=verbose,
         callbacks=[logging_handler],
     )
 
     # LLM to use in final prompt
     answer_callbacks.append(logging_handler)
     chatllm = ChatOpenAI(
-        model_name=environ.get('QA_COMPLETIONS_MODEL'),
-        temperature=float(environ.get('QA_TEMPERATURE', 0)),
+        model_name=model_name,
+        temperature=float(temperature),
         max_tokens=int(environ.get('QA_MAX_TOKENS', 800)),
         callbacks=answer_callbacks,
         streaming=streaming,
-        verbose=environ.get('VERBOSE_MODE', False),
+        verbose=verbose,
     )
 
     # this chain use "stuff" to elaborate context
@@ -163,7 +166,7 @@ def conversation_chain(
         llm=chatllm,
         prompt=load_brevia_prompt(prompts),
         chain_type="stuff",
-        verbose=environ.get('VERBOSE_MODE', False),
+        verbose=verbose,
         callbacks=[logging_handler],
     )
 
@@ -177,7 +180,7 @@ def conversation_chain(
         return_source_documents=source_docs,
         question_generator=question_generator,
         callbacks=conversation_callbacks,
-        verbose=environ.get('VERBOSE_MODE', False)
+        verbose=verbose,
     )
 
 

--- a/brevia/routers/qa_router.py
+++ b/brevia/routers/qa_router.py
@@ -95,9 +95,7 @@ def chat_language(prompt: PromptBody, cmetadata: dict) -> str:
     if chat_lang:
         return chat_lang
 
-    langDetector = Detector()
-
-    return langDetector.detect(prompt.question)
+    return Detector().detect(prompt.question)
 
 
 def prompt_chat_history(history: list, question: str, session: str = None) -> list:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,45 +3,45 @@ name = "brevia"
 version = "0.0.3"
 description = ""
 authors = [
-  "Niki Corradetti <niki.corradetti@atlasconsulting.it>",
-  "Stefano Rosanelli <stefano.rosanelli@atlasconsulting.it>"
+    "Niki Corradetti <niki.corradetti@atlasconsulting.it>",
+    "Stefano Rosanelli <stefano.rosanelli@atlasconsulting.it>",
 ]
 readme = "README.md"
 homepage = "https://github.com/brevia-ai/brevia"
 repository = "https://github.com/brevia-ai/brevia"
 
-  [tool.poetry.dependencies]
-  python = "^3.10"
-  bs4 = "^0.0.1"
-  lxml = "^4.9.2"
-  langchain = "0.0.240"
-  fastapi = "^0.95.2"
-  nltk = "^3.8.1"
-  openai = "^0.27.7"
-  pgvector = "^0.1.8"
-  psycopg2-binary = "^2.9.6"
-  pypdf = "^3.9.0"
-  python-dotenv = "^1.0.0"
-  python-multipart = "^0.0.6"
-  tiktoken = "^0.4.0"
-  spacy-fastlang = "^1.0.1"
-  langcodes = "^3.3.0"
-  language-data = "^1.1"
-  pycryptodome = "^3.18.0"
-  alembic = "^1.11.1"
-  python-jose = "^3.3.0"
-  sqlalchemy-utils = "^0.41.1"
+[tool.poetry.dependencies]
+python = "^3.10"
+bs4 = "^0.0.1"
+lxml = "^4.9.2"
+langchain = "0.0.240"
+fastapi = "^0.95.2"
+nltk = "^3.8.1"
+openai = "^0.27.7"
+pgvector = "^0.1.8"
+psycopg2-binary = "^2.9.6"
+pypdf = "^3.9.0"
+python-dotenv = "^1.0.0"
+python-multipart = "^0.0.6"
+tiktoken = "^0.4.0"
+spacy-fastlang = "^1.0.1"
+langcodes = "^3.3.0"
+language-data = "^1.1"
+pycryptodome = "^3.18.0"
+alembic = "^1.11.1"
+python-jose = "^3.3.0"
+sqlalchemy-utils = "^0.41.1"
 
-    [tool.poetry.dependencies.uvicorn]
-    extras = [ "standard" ]
-    version = "^0.22.0"
+[tool.poetry.dependencies.uvicorn]
+extras = ["standard"]
+version = "^0.22.0"
 
-  [tool.poetry.scripts]
-  create_token = "brevia.tokens:create_access_token"
-  test_service = "brevia.scripts.test_service:test_service"
-  db_current = "brevia.commands:db_current_cmd"
-  db_upgrade = "brevia.commands:db_upgrade_cmd"
-  db_downgrade = "brevia.commands:db_downgrade_cmd"
+[tool.poetry.scripts]
+create_token = "brevia.tokens:create_access_token"
+test_service = "brevia.scripts.test_service:test_service"
+db_current = "brevia.commands:db_current_cmd"
+db_upgrade = "brevia.commands:db_upgrade_cmd"
+db_downgrade = "brevia.commands:db_downgrade_cmd"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^6.1.0"
@@ -52,12 +52,12 @@ httpx = "^0.25.0"
 
 [tool.pylint.main]
 fail-under = 9.5
-ignore = [ ".git", "venv", ".venv", "data" ]
+ignore = [".git", "venv", ".venv", "data"]
 limit-inference-results = 100
 persistent = true
 py-version = "3.10"
-extension-pkg-whitelist = [ "pydantic" ]
+extension-pkg-whitelist = ["pydantic"]
 
 [build-system]
-requires = [ "poetry-core" ]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR introduces some Q/A default behaviors that can be stored in `collections` metadata.

In `cmetadata` JSON field of a collection you can now store:
* `chat_lang` language to use to answer questions in Q/A flow
* `docs_num` default number of documents used in search and Q/A (`SEARCH_NUM_DOCS` env var used as fallback)
* `model_name` model to use in Q/A flow (`QA_MODEL` env var used as fallback)
* `temperature` temperature parameter to use (`QA_TEMPERATURE` env var used as fallback)

`chat_lang` can now be passed in `/prompt` endpoint and takes precedence over the collection parameter

Changes in environment variables:
* `FEATURE_QA_LANG_DETECT` (default False) is used to enable language detection of question in Q/A flow using `Spacy`, if this variable is not set automatic language detection is skipped
* `QA_COMPLETIONS_MODEL` has been replaced with `QA_MODEL` 
 