### PR TITLE
Add `session_id` filter to chat history

### DIFF
--- a/brevia/chat_history.py
+++ b/brevia/chat_history.py
@@ -145,7 +145,7 @@ class ChatHistoryFilter(PydanticModel):
 
 def get_history(filter: ChatHistoryFilter) -> dict:
     """
-        Read chat history with optional date and collection filters
+        Read chat history with optional filters
         using pagination data in response
     """
     max_date = datetime.now() if filter.max_date is None else filter.max_date
@@ -155,7 +155,7 @@ def get_history(filter: ChatHistoryFilter) -> dict:
         filter_collection = CollectionStore.name is not None
     filter_session_id = sqlalchemy.text('1 = 1')  # (default) always true expression
     if filter.session_id and is_valid_uuid(filter.session_id):
-        filter_session_id = ChatHistoryStore.session_id = UUID(filter.session_id)
+        filter_session_id = ChatHistoryStore.session_id == filter.session_id
 
     page = max(1, filter.page)  # min page number is 1
     page_size = min(1000, filter.page_size)  # max page size is 1000

--- a/brevia/chat_history.py
+++ b/brevia/chat_history.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from langchain.vectorstores.pgvector import BaseModel
 from langchain.vectorstores._pgvector_data_models import CollectionStore
+from pydantic import BaseModel as PydanticModel
 import sqlalchemy
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.orm import Mapped, Query, Session
@@ -132,25 +133,32 @@ def is_valid_uuid(val) -> bool:
         return False
 
 
-def get_history(
-    min_date: str | None = None,
-    max_date: str | None = None,
-    collection: str | None = None,
-    page: int = 1,
-    page_size: int = 50,
-) -> dict:
+class ChatHistoryFilter(PydanticModel):
+    """ Chat history filter """
+    min_date: str | None = None
+    max_date: str | None = None
+    collection: str | None = None
+    session_id: str | None = None
+    page: int = 1
+    page_size: int = 50
+
+
+def get_history(filter: ChatHistoryFilter) -> dict:
     """
         Read chat history with optional filters
         using pagination data in response
     """
-    max_date = datetime.now() if max_date is None else max_date
-    min_date = datetime.fromtimestamp(0) if min_date is None else min_date
-    filter_collection = CollectionStore.name == collection
-    if collection is None:
+    max_date = datetime.now() if filter.max_date is None else filter.max_date
+    min_date = datetime.fromtimestamp(0) if filter.min_date is None else filter.min_date
+    filter_collection = CollectionStore.name == filter.collection
+    if filter.collection is None:
         filter_collection = CollectionStore.name is not None
+    filter_session_id = sqlalchemy.text('1 = 1')  # (default) always true expression
+    if filter.session_id and is_valid_uuid(filter.session_id):
+        filter_session_id = ChatHistoryStore.session_id == filter.session_id
 
-    page = max(1, page)  # min page number is 1
-    page_size = min(1000, page_size)  # max page size is 1000
+    page = max(1, filter.page)  # min page number is 1
+    page_size = min(1000, filter.page_size)  # max page size is 1000
     offset = (page - 1) * page_size
 
     with Session(db_connection()) as session:
@@ -159,6 +167,7 @@ def get_history(
             filter_min_date=ChatHistoryStore.created >= min_date,
             filter_max_date=ChatHistoryStore.created <= max_date,
             filter_collection=filter_collection,
+            filter_session_id=filter_session_id,
         )
         count = query.count()
         results = [u._asdict() for u in query.offset(offset).limit(page_size).all()]
@@ -185,6 +194,7 @@ def get_history_query(
     filter_min_date: BinaryExpression,
     filter_max_date: BinaryExpression,
     filter_collection: BinaryExpression,
+    filter_session_id: BinaryExpression,
 ) -> Query:
     """Return get history query"""
     return (
@@ -200,6 +210,6 @@ def get_history_query(
             CollectionStore,
             CollectionStore.uuid == ChatHistoryStore.collection_id
         )
-        .filter(filter_min_date, filter_max_date, filter_collection)
+        .filter(filter_min_date, filter_max_date, filter_collection, filter_session_id)
         .order_by(sqlalchemy.desc(ChatHistoryStore.created))
     )

--- a/brevia/routers/chat_history_router.py
+++ b/brevia/routers/chat_history_router.py
@@ -1,24 +1,13 @@
 """API endpoints definitions to handle audio input"""
-from fastapi import APIRouter
+from typing_extensions import Annotated
+from fastapi import APIRouter, Depends
 from brevia.dependencies import get_dependencies
-from brevia import chat_history
+from brevia.chat_history import get_history, ChatHistoryFilter
 
 router = APIRouter()
 
 
 @router.get('/chat_history', dependencies=get_dependencies(json_content_type=False))
-def read_chat_history(
-    min_date: str | None = None,
-    max_date: str | None = None,
-    collection: str | None = None,
-    page: int = 1,
-    page_size: int = 50,
-):
+def read_chat_history(filter: Annotated[ChatHistoryFilter, Depends()]):
     """ /chat_history endpoint, read stored chat history """
-    return chat_history.get_history(
-        min_date=min_date,
-        max_date=max_date,
-        collection=collection,
-        page=page,
-        page_size=page_size,
-    )
+    return get_history(filter=filter)

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -7,6 +7,7 @@ from brevia.chat_history import (
     add_history,
     history_from_db,
     get_history,
+    ChatHistoryFilter,
 )
 from brevia.collections import create_collection
 
@@ -40,7 +41,7 @@ def test_add_history_failure():
 
 def test_get_history():
     """Test get_history function"""
-    history_items = get_history()
+    history_items = get_history(filter=ChatHistoryFilter())
     expected = {
         'data': [],
         'meta': {
@@ -63,17 +64,23 @@ def test_get_history_filters():
     add_history(session_id, 'test_collection', 'who?', 'me')
     yesterday = datetime.strftime(datetime.now() - timedelta(1), '%Y-%m-%d')
     tomorrow = datetime.strftime(datetime.now() + timedelta(1), '%Y-%m-%d')
-    result = get_history(min_date=yesterday)
+    result = get_history(ChatHistoryFilter(min_date=yesterday))
     assert result['meta']['pagination']['count'] == 1
-    result = get_history(min_date=tomorrow)
+    result = get_history(ChatHistoryFilter(min_date=tomorrow))
     assert result['meta']['pagination']['count'] == 0
-    result = get_history(max_date=tomorrow)
+    result = get_history(ChatHistoryFilter(max_date=tomorrow))
     assert result['meta']['pagination']['count'] == 1
-    result = get_history(min_date=yesterday, collection='test_collection')
+    result = get_history(ChatHistoryFilter(
+        min_date=yesterday, collection='test_collection'
+    ))
     assert result['meta']['pagination']['count'] == 1
-    result = get_history(min_date=tomorrow, max_date=tomorrow)
+    result = get_history(ChatHistoryFilter(min_date=tomorrow, max_date=tomorrow))
     assert result['meta']['pagination']['count'] == 0
-    result = get_history(min_date=yesterday, collection='test2')
+    result = get_history(ChatHistoryFilter(min_date=yesterday, collection='test2'))
+    assert result['meta']['pagination']['count'] == 0
+    result = get_history(ChatHistoryFilter(session_id=str(session_id)))
+    assert result['meta']['pagination']['count'] == 1
+    result = get_history(ChatHistoryFilter(session_id=str(uuid.uuid4())))
     assert result['meta']['pagination']['count'] == 0
 
 


### PR DESCRIPTION
This PR adds a session_id filter to be used in `GET /chat_history` endpoint along with existing filters.

Example:

```
GET  /chat_history?session_id={uuid}&collection={collection}&min_date=2023-12-07
````
Retrieve a specific session on a collection starting from a date
