### PR TITLE
Add metadata filter in `/search` and `/chat`

### DIFF
--- a/brevia/postman/Brevia API.postman_collection.json
+++ b/brevia/postman/Brevia API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "06e8e501-9778-4afe-99ab-2423e7cf12ce",
+		"_postman_id": "8bcda8f4-e21c-4bf9-95ba-45f4405138a4",
 		"name": "Brevia API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "234034"
@@ -10,7 +10,7 @@
 			"name": "Chat",
 			"item": [
 				{
-					"name": "chat - Question/Answer flow",
+					"name": "chat - Question/Answer flow basic",
 					"request": {
 						"auth": {
 							"type": "bearer",
@@ -37,7 +37,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"question\" : \"quando è nata la repubblica in Italia?\",\n    \"collection\" : \"storia-novecento\",\n    \"source_docs\": true,\n    \"docs_num\": 3,\n    \"token_data\": false\n}"
+							"raw": "{\n    \"question\" : \"{{query}}\",\n    \"collection\" : \"{{collection}}\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/chat",
@@ -52,7 +52,49 @@
 					"response": []
 				},
 				{
-					"name": "chat - Question/Answer flow with History",
+					"name": "chat - Question/Answer flow with additional parameters",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "X-Chat-Session",
+								"value": "{{session_id}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"question\" : \"{{query}}\",\n    \"collection\" : \"{{collection}}\",\n    \"source_docs\": true,\n    \"docs_num\": 6,\n    \"token_data\": true\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/chat",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"chat"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "chat - Question/Answer flow with chat history",
 					"request": {
 						"auth": {
 							"type": "bearer",
@@ -74,7 +116,44 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"question\" : \"mi puoi tradurre l'ultima risposta in italiano?\",\n    \"chat_history\": [\n        {\n            \"query\": \"cos'è il floor?\",\n            \"answer\": \"Il floor è il minimo valore a cui è possibile convertire il proprio investimento in strumenti convertibili, che tutela l'imprenditore da un eccessivo ribasso della valutazione.\"\n        },\n        {\n            \"query\": \"cos'è il mifid?\",\n            \"answer\": \"MiFID sta per \\\"Markets in Financial Instruments Directive\\\", ovvero la direttiva sui mercati degli strumenti finanziari.\"\n        },\n        {\n            \"query\": \"quanto bisogna pagare per fare un finanziamento?\",\n            \"answer\": \"The cost of obtaining finance from Doorway varies depending on whether you are an investor or a company seeking funding. For investors, there is a 1% annual fee based on the investment amount for administrative and accounting costs, as well as a potential 20% commission on returns exceeding 7%. For companies seeking funding, Doorway charges a success fee between 6% and 8% of the amount raised.\"\n        }\n\n    ],\n    \"collection\" : \"doorway\"\n}"
+							"raw": "{\n    \"question\" : \"{{query}}\",\n    \"collection\" : \"{{collection}}\",\n    \"chat_history\": [\n        {\n            \"query\": \"what is artificial intelligence?\",\n            \"answer\": \"Artificial intelligence (AI) refers to the simulation or approximation of human intelligence in machines. The goals of artificial intelligence include computer-enhanced learning, reasoning, and perception\"\n        },\n        {\n            \"query\": \"Is AI good or bad?\",\n            \"answer\": \"These technologies not only save time, but also potentially save lives by minimizing human error and ensuring a safer working environment. In addition, automating repetitive tasks in design, planning, and management with AI frees up human workers to focus on more complex and creative aspects.\"\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/chat",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"chat"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "chat - Question/Answer flow with filter",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"question\" : \"{{query}}\",\n    \"collection\" : \"{{collection}}\",\n    \"filter\": {\"category\": \"first\"}\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/chat",
@@ -934,78 +1013,78 @@
 					},
 					"response": []
 				},
-                {
-                    "name": "upload_summarize - Custom prompt",
-                    "event": [
-                        {
-                            "listen": "test",
-                            "script": {
-                                "exec": [
-                                    "var responseJSON;",
-                                    "try {",
-                                    "    responseJSON = JSON.parse(responseBody); ",
-                                    "    tests[\"Status code is 200\"] = responseCode.code === 200;",
-                                    "    if (responseJSON && responseJSON.job) {",
-                                    "        postman.setEnvironmentVariable(\"job_id\", responseJSON.job);",
-                                    "    }",
-                                    "} catch (e) {",
-                                    "    tests[\"Error in parsing response\"] = e;",
-                                    "}"
-                                ],
-                                "type": "text/javascript"
-                            }
-                        }
-                    ],
-                    "protocolProfileBehavior": {
-                        "disabledSystemHeaders": {}
-                    },
-                    "request": {
-                        "auth": {
-                            "type": "bearer",
-                            "bearer": [
-                                {
-                                    "key": "token",
-                                    "value": "{{access_token}}",
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "method": "POST",
-                        "header": [],
-                        "body": {
-                            "mode": "formdata",
-                            "formdata": [
-                                {
-                                    "key": "file",
-                                    "type": "file",
-                                    "src": []
-                                },
-                                {
-                                    "key": "chain_type",
-                                    "value": "map_reduce",
-                                    "type": "text"
-                                },
-                                {
-                                    "key": "token_data",
-                                    "value": "true",
-                                    "type": "text"
-                                }
-                            ]
-                        },
-                        "url": {
-                            "raw": "{{baseUrl}}/upload_summarize",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "upload_summarize"
-                            ]
-                        }
-                    },
-                    "response": []
-                }
-            ]
-        },
+				{
+					"name": "upload_summarize - Custom prompt",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var responseJSON;",
+									"try {",
+									"    responseJSON = JSON.parse(responseBody); ",
+									"    tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"    if (responseJSON && responseJSON.job) {",
+									"        postman.setEnvironmentVariable(\"job_id\", responseJSON.job);",
+									"    }",
+									"} catch (e) {",
+									"    tests[\"Error in parsing response\"] = e;",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "file",
+									"type": "file",
+									"src": []
+								},
+								{
+									"key": "chain_type",
+									"value": "map_reduce",
+									"type": "text"
+								},
+								{
+									"key": "token_data",
+									"value": "true",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/upload_summarize",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"upload_summarize"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
 		{
 			"name": "Search",
 			"item": [

--- a/brevia/postman/Brevia API.postman_collection.json
+++ b/brevia/postman/Brevia API.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "1e6f7e98-9b53-4477-b01d-c6a8a0f2bdfd",
-		"name": "brevia API",
+		"_postman_id": "06e8e501-9778-4afe-99ab-2423e7cf12ce",
+		"name": "Brevia API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "4185449"
+		"_exporter_id": "234034"
 	},
 	"item": [
 		{
@@ -934,31 +934,83 @@
 					},
 					"response": []
 				},
+                {
+                    "name": "upload_summarize - Custom prompt",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "var responseJSON;",
+                                    "try {",
+                                    "    responseJSON = JSON.parse(responseBody); ",
+                                    "    tests[\"Status code is 200\"] = responseCode.code === 200;",
+                                    "    if (responseJSON && responseJSON.job) {",
+                                    "        postman.setEnvironmentVariable(\"job_id\", responseJSON.job);",
+                                    "    }",
+                                    "} catch (e) {",
+                                    "    tests[\"Error in parsing response\"] = e;",
+                                    "}"
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "protocolProfileBehavior": {
+                        "disabledSystemHeaders": {}
+                    },
+                    "request": {
+                        "auth": {
+                            "type": "bearer",
+                            "bearer": [
+                                {
+                                    "key": "token",
+                                    "value": "{{access_token}}",
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "method": "POST",
+                        "header": [],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": [
+                                {
+                                    "key": "file",
+                                    "type": "file",
+                                    "src": []
+                                },
+                                {
+                                    "key": "chain_type",
+                                    "value": "map_reduce",
+                                    "type": "text"
+                                },
+                                {
+                                    "key": "token_data",
+                                    "value": "true",
+                                    "type": "text"
+                                }
+                            ]
+                        },
+                        "url": {
+                            "raw": "{{baseUrl}}/upload_summarize",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "upload_summarize"
+                            ]
+                        }
+                    },
+                    "response": []
+                }
+            ]
+        },
+		{
+			"name": "Search",
+			"item": [
 				{
-					"name": "upload_summarize - Custom prompt",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var responseJSON;",
-									"try {",
-									"    responseJSON = JSON.parse(responseBody); ",
-									"    tests[\"Status code is 200\"] = responseCode.code === 200;",
-									"    if (responseJSON && responseJSON.job) {",
-									"        postman.setEnvironmentVariable(\"job_id\", responseJSON.job);",
-									"    }",
-									"} catch (e) {",
-									"    tests[\"Error in parsing response\"] = e;",
-									"}"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"protocolProfileBehavior": {
-						"disabledSystemHeaders": {}
-					},
+					"name": "search - Basic search",
 					"request": {
 						"auth": {
 							"type": "bearer",
@@ -971,34 +1023,98 @@
 							]
 						},
 						"method": "POST",
-						"header": [],
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
 						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "file",
-									"type": "file",
-									"src": []
-								},
-								{
-									"key": "chain_type",
-									"value": "map_reduce",
-									"type": "text"
-								},
-								{
-									"key": "token_data",
-									"value": "true",
-									"type": "text"
-								}
-							]
+							"mode": "raw",
+							"raw": "{\r\n    \"query\" : \"{{query}}\",\r\n    \"collection\" : \"{{collection}}\"\r\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/upload_summarize",
+							"raw": "{{baseUrl}}/search",
 							"host": [
 								"{{baseUrl}}"
 							],
 							"path": [
-								"upload_summarize"
+								"search"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "search - Search with additional parameters",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"query\" : \"{{query}}\",\r\n    \"collection\" : \"{{collection}}\",\r\n    \"docs_num\" : 6,\r\n    \"distance_strategy_name\" : \"euclidean\"\r\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/search",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"search"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "search - Search with metadata filter",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"query\" : \"{{query}}\",\r\n    \"collection\" : \"{{collection}}\",\r\n    \"filter\": {\"category\": \"first\", \"type\": {\"in\": [\"a\", \"b\"]}}\r\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/search",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"search"
 							]
 						}
 					},
@@ -1116,43 +1232,6 @@
 					],
 					"path": [
 						"transcribe"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "search - Relevant documents",
-			"request": {
-				"auth": {
-					"type": "bearer",
-					"bearer": [
-						{
-							"key": "token",
-							"value": "{{access_token}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"query\" : \"cos'è il floor?\",\r\n    \"collection\" : \"doorway\",\r\n    \"docs_num\" : 6,\r\n    \"distance_strategy_name\" : \"cosine\"\r\n}"
-				},
-				"url": {
-					"raw": "{{baseUrl}}/search",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"search"
 					]
 				}
 			},

--- a/brevia/postman/Brevia API.postman_environment.json
+++ b/brevia/postman/Brevia API.postman_environment.json
@@ -1,16 +1,16 @@
 {
 	"id": "fcc469d4-ed0e-4ee8-b27a-ee0002dce64a",
-	"name": "brevia API",
+	"name": "Brevia API",
 	"values": [
 		{
 			"key": "baseUrl",
-			"value": "http://localhost:5000",
+			"value": "http://localhost:8000",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "collection",
-			"value": "",
+			"value": "my-collection",
 			"type": "default",
 			"enabled": true
 		},
@@ -46,18 +46,24 @@
 		},
 		{
 			"key": "service",
-			"value": "{}",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "service_payload",
-			"value": "",
+			"value": "{}",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "query",
+			"value": "what is a LLM?",
 			"type": "default",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-08-08T13:58:35.253Z",
-	"_postman_exported_using": "Postman/10.16.5"
+	"_postman_exported_at": "2023-12-11T09:48:12.459Z",
+	"_postman_exported_using": "Postman/10.20.10"
 }

--- a/brevia/query.py
+++ b/brevia/query.py
@@ -90,7 +90,7 @@ class SearchQuery(BaseModel):
     collection: str
     docs_num: int | None = None
     distance_strategy_name: str = 'cosine',
-    filter: dict[str, str] | None = None
+    filter: dict[str, str | dict] | None = None
 
 
 def search_vector_qa(

--- a/brevia/query.py
+++ b/brevia/query.py
@@ -16,6 +16,7 @@ from langchain.prompts import (
     HumanMessagePromptTemplate,
 )
 from langchain.prompts.loading import load_prompt_from_config
+from pydantic import BaseModel
 from brevia.connection import connection_string
 from brevia.collections import single_collection_by_name
 from brevia.callback import AsyncLoggingCallbackHandler
@@ -83,37 +84,52 @@ DISTANCE_MAP = {
 }
 
 
-def search_vector_qa(
-    query: str,
-    collection: str,
-    docs_num: int | None = None,
+class SearchQuery(BaseModel):
+    """ Search query items """
+    query: str
+    collection: str
+    docs_num: int | None = None
     distance_strategy_name: str = 'cosine',
+    filter: dict[str, str] | None = None
+
+
+def search_vector_qa(
+    search: SearchQuery,
 ) -> list[tuple[Document, float]]:
     """ Perform a similarity search on vector index """
-    collection_store = single_collection_by_name(collection)
+    collection_store = single_collection_by_name(search.collection)
     if not collection_store:
-        raise ValueError(f'Collection not found: {collection}')
-    if docs_num is None:
+        raise ValueError(f'Collection not found: {search.collection}')
+    if search.docs_num is None:
         default_num = get_settings().search_docs_num
-        docs_num = int(collection_store.cmetadata.get('docs_num', default_num))
-    strategy = DISTANCE_MAP.get(distance_strategy_name, DistanceStrategy.COSINE)
+        search.docs_num = int(collection_store.cmetadata.get('docs_num', default_num))
+    strategy = DISTANCE_MAP.get(search.distance_strategy_name, DistanceStrategy.COSINE)
     docsearch = PGVector(
         connection_string=connection_string(),
         embedding_function=load_embeddings(),
-        collection_name=collection,
+        collection_name=search.collection,
         distance_strategy=strategy,
     )
 
-    return docsearch.similarity_search_with_score(query, k=docs_num)
+    return docsearch.similarity_search_with_score(
+        query=search.query,
+        k=search.docs_num,
+        filter=search.filter,
+    )
+
+
+class ChatParams(BaseModel):
+    """ Q&A basic conversation chain params"""
+    docs_num: int | None = None
+    streaming: bool = False
+    distance_strategy_name: str | None = None
+    filter: dict[str, str] | None = None
+    source_docs: bool = False
 
 
 def conversation_chain(
-    # pylint: disable=too-many-arguments
     collection: CollectionStore,
-    docs_num: int | None = None,
-    source_docs: bool = True,
-    distance_strategy_name: str = 'cosine',
-    streaming: bool = False,
+    chat_params: ChatParams,
     answer_callbacks: list[BaseCallbackHandler] | None = None,
     conversation_callbacks: list[BaseCallbackHandler] | None = None,
 ) -> Chain:
@@ -121,11 +137,13 @@ def conversation_chain(
         Return conversation chain for Q/A with embdedded dataset knowledge
 
         collection: collection store item
-        docs_num: number of docs to retrieve to create context
-            (default 'SEARCH_DOCS_NUM' env var or '4')
-        source_docs: flag to retrieve source docs in response (default True)
-        distance_strategy_name: distance strategy to use (default 'cosine')
-        streaming: activate streaming (default False),
+        chat_params: basic conversation chain parameters, including:
+            docs_num: number of docs to retrieve to create context
+                (default 'SEARCH_DOCS_NUM' env var or '4')
+            streaming: activate streaming (default False),
+            distance_strategy_name: distance strategy to use (default 'cosine')
+            filter: optional dictionary of metadata to use as filter (defailt None)
+            source_docs: flag to retrieve source docs in response (default True)
         answer_callbacks: callbacks to use in the final LLM answer to enable streaming
             (default empty list)
         conversation_callbacks: callback to handle conversation results
@@ -137,15 +155,18 @@ def conversation_chain(
             }
     """
     settings = get_settings()
-    if docs_num is None:
+    if chat_params.docs_num is None:
         default_num = settings.search_docs_num
-        docs_num = int(collection.cmetadata.get('docs_num', default_num))
+        chat_params.docs_num = int(collection.cmetadata.get('docs_num', default_num))
     if answer_callbacks is None:
         answer_callbacks = []
     if conversation_callbacks is None:
         conversation_callbacks = []
 
-    strategy = DISTANCE_MAP.get(distance_strategy_name, DistanceStrategy.COSINE)
+    strategy = DISTANCE_MAP.get(
+        chat_params.distance_strategy_name,
+        DistanceStrategy.COSINE
+    )
     docsearch = PGVector(
         connection_string=connection_string(),
         embedding_function=load_embeddings(),
@@ -180,7 +201,7 @@ def conversation_chain(
     # Model to use in final prompt
     answer_callbacks.append(logging_handler)
     qa_llm_conf['callbacks'] = answer_callbacks
-    qa_llm_conf['streaming'] = streaming
+    qa_llm_conf['streaming'] = chat_params.streaming
     chatllm = load_chatmodel(qa_llm_conf)
 
     # this chain use "stuff" to elaborate context
@@ -193,13 +214,13 @@ def conversation_chain(
     )
 
     # main chain, do all the jobs
-    search_kwargs = {'k': docs_num}
+    search_kwargs = {'k': chat_params.docs_num, 'filter': chat_params.filter}
 
     conversation_callbacks.append(logging_handler)
     return ConversationalRetrievalChain(
         retriever=docsearch.as_retriever(search_kwargs=search_kwargs),
         combine_docs_chain=doc_chain,
-        return_source_documents=source_docs,
+        return_source_documents=chat_params.source_docs,
         question_generator=question_generator,
         callbacks=conversation_callbacks,
         verbose=verbose,

--- a/brevia/routers/qa_router.py
+++ b/brevia/routers/qa_router.py
@@ -6,29 +6,25 @@ from langchain.callbacks.openai_info import OpenAICallbackHandler
 from langchain.chains.base import Chain
 from fastapi import APIRouter, Header
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
-from brevia import query, chat_history
+from brevia import chat_history
 from brevia.dependencies import (
     get_dependencies,
     check_collection_name,
 )
 from brevia.callback import ConversationCallbackHandler
 from brevia.language import Detector
+from brevia.query import SearchQuery, ChatParams, conversation_chain, search_vector_qa
 from brevia.models import test_models_in_use
 
 router = APIRouter()
 
 
-class ChatBody(BaseModel):
+class ChatBody(ChatParams):
     """ /chat request body """
     question: str
     collection: str
     chat_history: list = []
-    docs_num: int | None = None
     chat_lang: str | None = None
-    streaming: bool = False
-    distance_strategy_name: str | None = None
-    source_docs: bool = False
     token_data: bool = False
 
 
@@ -46,10 +42,9 @@ async def chat_action(
 
     conversation_handler = ConversationCallbackHandler()
     stream_handler = AsyncIteratorCallbackHandler()
-    chain = query.conversation_chain(
+    chain = conversation_chain(
         collection=collection,
-        docs_num=chat_body.docs_num,
-        streaming=chat_body.streaming,
+        chat_params=ChatParams(**chat_body.model_dump()),
         answer_callbacks=[stream_handler] if chat_body.streaming else [],
         conversation_callbacks=[conversation_handler]
     )
@@ -164,16 +159,8 @@ def chat_result(
     }
 
 
-class SearchBody(BaseModel):
-    """ /search request body """
-    query: str
-    collection: str
-    docs_num: int | None = None
-    distance_strategy_name: str | None = None
-
-
 @router.post('/search', dependencies=get_dependencies())
-def search_documents(search: SearchBody):
+def search_documents(search: SearchQuery):
     """
         /search endpoint:
         Search the first {docs_num} relevant documents for a question
@@ -184,11 +171,9 @@ def search_documents(search: SearchBody):
             MAX_INNER_PRODUCT = EmbeddingStore.embedding.max_inner_product
     """
     collection = check_collection_name(search.collection)
-
-    params = {k: v for k, v in search.model_dump().items() if v is not None}
-    if 'docs_num' not in params and 'docs_num' in collection.cmetadata:
-        params['docs_num'] = collection.cmetadata['docs_num']
-    result = query.search_vector_qa(**params)
+    if search.docs_num is None and 'docs_num' in collection.cmetadata:
+        search.docs_num = int(collection.cmetadata['docs_num'])
+    result = search_vector_qa(search=search)
 
     return extract_content_score(result)
 

--- a/tests/routers/test_qa_router.py
+++ b/tests/routers/test_qa_router.py
@@ -2,13 +2,16 @@
 from fastapi.testclient import TestClient
 from fastapi import FastAPI
 from langchain.docstore.document import Document
-from brevia.routers import qa_router
+from brevia.routers.qa_router import (
+    router, ChatBody, chat_language, retrieve_chat_history, extract_content_score
+)
 from brevia.collections import create_collection
 from brevia.index import add_document
+from brevia.settings import get_settings
 
 
 app = FastAPI()
-app.include_router(qa_router.router)
+app.include_router(router)
 client = TestClient(app)
 
 
@@ -27,7 +30,7 @@ def test_prompt():
 
 def test_search():
     """Test POST /search endpoint"""
-    create_collection('test_collection', {})
+    create_collection('test_collection', {'docs_num': 3})
     add_document(
         document=Document(page_content='Lorem ipsum'),
         collection_name='test_collection',
@@ -41,3 +44,28 @@ def test_search():
     assert response.status_code == 200
     data = response.json()
     assert data is not None
+
+
+def test_chat_language():
+    """Test chat_language method"""
+    chat_body = ChatBody(question='', collection='', chat_lang='Klingon')
+    lang = chat_language(chat_body=chat_body, cmetadata={})
+    assert lang == 'Klingon'
+
+
+def test_retrieve_chat_history():
+    """Test retrieve_chat_history method"""
+    settings = get_settings()
+    thresh = settings.qa_followup_sim_threshold
+    settings.qa_followup_sim_threshold = 100
+    history = [{'query': 'a', 'answer': 'b'}]
+    chat_hist = retrieve_chat_history(history=history, question='c')
+    assert len(chat_hist) == 0
+    # restore threshold
+    settings.qa_followup_sim_threshold = thresh
+
+
+def test_extract_content_score():
+    """Test extract_content_score method"""
+    result = extract_content_score(data_list={'error': 'big problems!'})
+    assert result == {'error': 'big problems!'}

--- a/tests/routers/test_qa_router.py
+++ b/tests/routers/test_qa_router.py
@@ -1,4 +1,5 @@
 """Q/A router tests"""
+from json import dumps
 from fastapi.testclient import TestClient
 from fastapi import FastAPI
 from langchain.docstore.document import Document
@@ -44,6 +45,29 @@ def test_search():
     assert response.status_code == 200
     data = response.json()
     assert data is not None
+
+
+def test_search_filter():
+    """Test POST /search with metadata filter"""
+    create_collection('test_collection', {})
+    doc1 = Document(page_content='some', metadata={'category': 'first'})
+    add_document(document=doc1, collection_name='test_collection')
+    doc2 = Document(page_content='some', metadata={'category': 'second'})
+    add_document(document=doc2, collection_name='test_collection')
+
+    body = {
+        'query': 'How?',
+        'collection': 'test_collection',
+        'filter': {'category': 'first'},
+    }
+    response = client.post(
+        '/search',
+        headers={'Content-Type': 'application/json'},
+        content=dumps(body),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
 
 
 def test_chat_language():

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,14 +1,16 @@
 """Query module tests"""
 import pytest
+from langchain.prompts import BasePromptTemplate
+from langchain.chains import ConversationalRetrievalChain
 from brevia.query import (
     conversation_chain,
     load_qa_prompt,
     load_condense_prompt,
     search_vector_qa,
+    ChatParams,
+    SearchQuery,
 )
 from brevia.collections import create_collection
-from langchain.prompts import BasePromptTemplate
-from langchain.chains import ConversationalRetrievalChain
 
 FAKE_PROMPT = {
     '_type': 'prompt',
@@ -50,14 +52,14 @@ def test_load_condense_prompt():
 def test_search_vector_qa():
     """Test search_vector_qa function"""
     with pytest.raises(ValueError) as exc:
-        search_vector_qa(query='test', collection='test')
+        search_vector_qa(search=SearchQuery(query='test', collection='test'))
     assert str(exc.value) == 'Collection not found: test'
 
 
 def test_conversation_chain():
     """Test conversation_chain function"""
     collection = create_collection('test', {})
-    chain = conversation_chain(collection=collection)
+    chain = conversation_chain(collection=collection, chat_params=ChatParams())
 
     assert chain is not None
     assert isinstance(chain, ConversationalRetrievalChain)


### PR DESCRIPTION
This PR adds support for metadata filters in both `/search` and `/chat` endpoints.

It is now possible to introduce filters like these: 

```http
POST /search
{
   "query": "my query...",
   "collection": "my-collection",
   "filter": {"category": "my-category"} 
}
```

```http
POST /chat
{
   "question": "my question is: ...",
   "collection": "my-collection",
   "filter": {"category": {"in": ["first", "second"]}} 
}
```

There are two filter type available: you can combine metadata filter by using specific keys and values or by using `IN` conditions with a dictionary object like in the second examples.

Other changes:

* new `SearchQuery` and `ChatParams` pydantic models have been added to handle common fields in search and chat use cases
* unit and integration tests have been added to `query` and `router.qa_router` modules