### PR TITLE
Fix tests settings

### DIFF
--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -1,6 +1,6 @@
 """Settings module"""
 from functools import lru_cache
-from typing import Iterable, Any
+from typing import Any
 from os import environ
 from pydantic import Json
 from pydantic_settings import BaseSettings, SettingsConfigDict

--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -86,11 +86,13 @@ class Settings(BaseSettings):
 
     def update(
         self,
-        other: Iterable[tuple[str, Any]],
+        other: dict[str, Any],
     ) -> None:
         """Update settings fields, used in unit tests"""
-        for field_name, value in other:
-            setattr(self, field_name, value)
+        for field_name in other.keys():
+            key = field_name.lower()
+            if hasattr(self, key):
+                setattr(self, key, other.get(field_name))
 
     def setup_environment(self):
         """Setup some useful environment variables"""
@@ -103,11 +105,11 @@ class Settings(BaseSettings):
             environ['LANGCHAIN_ENDPOINT'] = self.langchain_endpoint
             environ['LANGCHAIN_API_KEY'] = self.langchain_api_key
             environ['LANGCHAIN_PROJECT'] = self.langchain_project
-        return
 
 
 @lru_cache
 def get_settings():
+    """Return Settings object instance just once (using lru_cache)"""
     settings = Settings()
     settings.setup_environment()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
-import pytest
+"""Configure settings and fixtures to be used in unit tests"""
 from pathlib import Path
+import pytest
 from alembic import command
 from alembic.config import Config
+from dotenv import dotenv_values
 from brevia.index import init_index
-from brevia.settings import Settings, get_settings
+from brevia.settings import get_settings
 
 
 def pytest_sessionstart(session):
@@ -13,9 +15,10 @@ def pytest_sessionstart(session):
 
 def update_settings():
     """Update settings reading from `tests/.env` file"""
-    new_settings = Settings(_env_file=['.env', f'{Path(__file__).parent}/.env'])
+    new_settings = dotenv_values(dotenv_path=f'{Path(__file__).parent}/.env')
     settings = get_settings()
     settings.update(new_settings)
+    settings.setup_environment()
     # Force tokens and test models vars
     settings.tokens_secret = ''
     settings.tokens_users = ''

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,7 +21,6 @@ from brevia.models import (
 def test_load_llm():
     """ Test load_llm """
     result = load_llm({'_type': 'openai'})
-    print(result)
     assert isinstance(result, FakeBreviaLLM)
     assert result.get_token_ids('') == [10] * 10
 


### PR DESCRIPTION
This PR fixes a problem with test settings: values in `tests/.env` file were not overriding ones in `Settings` instance as expected in unit tests