### PR TITLE
Update document index metadata endpoint

### DIFF
--- a/brevia/index.py
+++ b/brevia/index.py
@@ -105,3 +105,17 @@ def read_document(
         query = session.query(EmbeddingStore.document, EmbeddingStore.cmetadata)
         query = query.filter(filter_collection, filter_document)
         return [row._asdict() for row in query.all()]
+
+
+def update_metadata(
+    collection_id: str,
+    document_id: str,
+    metadata: dict | None = None,
+):
+    """ Update index metadata"""
+    filter_document = EmbeddingStore.custom_id == document_id
+    filter_collection = EmbeddingStore.collection_id == collection_id
+    with Session(connection.db_connection()) as session:
+        query = session.query(EmbeddingStore).filter(filter_collection, filter_document)
+        query.update({EmbeddingStore.cmetadata: metadata})
+        session.commit()

--- a/brevia/index.py
+++ b/brevia/index.py
@@ -112,7 +112,7 @@ def update_metadata(
     document_id: str,
     metadata: dict | None = None,
 ):
-    """ Update index metadata"""
+    """ Update metadata of a document in a collection"""
     filter_document = EmbeddingStore.custom_id == document_id
     filter_collection = EmbeddingStore.collection_id == collection_id
     with Session(connection.db_connection()) as session:

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -7,7 +7,11 @@ from pydantic import BaseModel
 from fastapi import APIRouter, HTTPException, status, UploadFile, Form
 from langchain.docstore.document import Document
 from langchain_community.vectorstores.pgembedding import CollectionStore
-from brevia.dependencies import get_dependencies, save_upload_file_tmp
+from brevia.dependencies import (
+    get_dependencies,
+    save_upload_file_tmp,
+    check_collection_uuid,
+)
 from brevia import index, collections, load_file
 
 router = APIRouter()
@@ -116,4 +120,22 @@ def read_document(collection_id: str, document_id: str):
     return index.read_document(
         collection_id=collection_id,
         document_id=document_id,
+    )
+
+
+class IndexMetaBody(BaseModel):
+    """ /index/metadata request body """
+    collection_id: str
+    document_id: str
+    metadata: dict = {}
+
+
+@router.post('/index/metadata', status_code=204, dependencies=get_dependencies())
+def index_metadata_document(item: IndexMetaBody):
+    """ Update metadata of a single collection document """
+    check_collection_uuid(item.collection_id)
+    index.update_metadata(
+        collection_id=item.collection_id,
+        document_id=item.document_id,
+        metadata=item.metadata,
     )

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -132,7 +132,7 @@ class IndexMetaBody(BaseModel):
 
 @router.post('/index/metadata', status_code=204, dependencies=get_dependencies())
 def index_metadata_document(item: IndexMetaBody):
-    """ Update metadata of a single collection document """
+    """ Update metadata of a single document in a collection"""
     check_collection_uuid(item.collection_id)
     index.update_metadata(
         collection_id=item.collection_id,


### PR DESCRIPTION
This PR introduces a new endpoint to update metadata of a single documenta in a collection.

Example usage:

```http
POST /index/metadata
{
   "collection_id": "{uuid}",
   "document_id": "{doc_id}",
   "metadata": {"category": "second"},
}
```
Where `{uuid}` and `{doc_id}` are the requested collection and document id.
