### PR TITLE
Fix token usage callback error

### DIFF
--- a/brevia/callback.py
+++ b/brevia/callback.py
@@ -4,10 +4,28 @@ from uuid import UUID
 import asyncio
 import logging
 import json
+from langchain.callbacks import get_openai_callback
 from langchain.callbacks.base import BaseCallbackHandler, AsyncCallbackHandler
 from langchain.docstore.document import Document
 from langchain.schema import BaseMessage
 from langchain.schema.output import LLMResult
+from langchain.callbacks.openai_info import OpenAICallbackHandler
+
+# Only OpenAI token usage callback handler is supported for now
+# other LLMs will always return 0 as tokens usage (for now)
+token_usage_callback = get_openai_callback
+TokensCallbackHandler = OpenAICallbackHandler
+
+
+def token_usage(callb: TokensCallbackHandler) -> dict[str, int | float]:
+    """Tokens usage and costs details (only OpenAI for now)"""
+    return {
+        'completion_tokens': callb.completion_tokens,
+        'prompt_tokens': callb.prompt_tokens,
+        'total_tokens': callb.total_tokens,
+        'successful_requests': callb.successful_requests,
+        'total_cost': callb.total_cost,
+    }
 
 
 class ConversationCallbackHandler(AsyncCallbackHandler):

--- a/brevia/routers/qa_router.py
+++ b/brevia/routers/qa_router.py
@@ -1,8 +1,7 @@
 """API endpoints for question answering and search"""
 from typing import Annotated
 import asyncio
-from langchain.callbacks import AsyncIteratorCallbackHandler, get_openai_callback
-from langchain.callbacks.openai_info import OpenAICallbackHandler
+from langchain.callbacks import AsyncIteratorCallbackHandler
 from langchain.chains.base import Chain
 from fastapi import APIRouter, Header
 from fastapi.responses import StreamingResponse
@@ -11,7 +10,12 @@ from brevia.dependencies import (
     get_dependencies,
     check_collection_name,
 )
-from brevia.callback import ConversationCallbackHandler
+from brevia.callback import (
+    ConversationCallbackHandler,
+    token_usage_callback,
+    token_usage,
+    TokensCallbackHandler,
+)
 from brevia.language import Detector
 from brevia.query import SearchQuery, ChatParams, conversation_chain, search_vector_qa
 from brevia.models import test_models_in_use
@@ -116,7 +120,7 @@ async def run_chain(
     x_chat_session: str,
 ):
     """Run chain usign async methods and return result"""
-    with get_openai_callback() as callb:
+    with token_usage_callback() as callb:
         result = await chain.acall({
             'question': chat_body.question,
             'chat_history': retrieve_chat_history(
@@ -137,7 +141,7 @@ async def run_chain(
 
 def chat_result(
     result: dict,
-    callb: OpenAICallbackHandler,
+    callb: TokensCallbackHandler,
     chat_body: ChatBody,
     x_chat_session: str | None = None,
 ) -> dict:
@@ -149,13 +153,13 @@ def chat_result(
             collection=chat_body.collection,
             question=chat_body.question,
             answer=answer,
-            metadata=callb.__dict__,
+            metadata=token_usage(callb),
     )
 
     return {
         'bot': answer,
         'docs': None if not chat_body.source_docs else result['source_documents'],
-        'token_data': None if not chat_body.token_data else callb.__dict__
+        'token_data': None if not chat_body.token_data else token_usage(callb)
     }
 
 


### PR DESCRIPTION
This PR fixes a problem with token usage callback that generate an error when saving chat history items.

* a new `token_usage` function has been added to extract usage data
* `token_usage_callback` and `TokensCallbackHandler` aliases for future uses, only OpenAI token count is supported for now
 