### PR TITLE
Chat response user evaluation endpoint - `/evaluate`

### DIFF
--- a/brevia/alembic/versions/b34017752e45_chat_history_evaluation.py
+++ b/brevia/alembic/versions/b34017752e45_chat_history_evaluation.py
@@ -1,0 +1,52 @@
+"""chat history evaluation
+
+Revision ID: b34017752e45
+Revises: 1d927e0cbc61
+Create Date: 2024-01-17 11:10:55.127272
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b34017752e45'
+down_revision = '1d927e0cbc61'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'chat_history',
+        sa.Column(
+            'user_evaluation',
+            sa.BOOLEAN(),
+            nullable=True,
+            comment='User evaluation as good (True) or bad (False)',
+        ),
+    )
+    op.add_column(
+        'chat_history',
+        sa.Column(
+            'user_feedback',
+            sa.String(),
+            nullable=True,
+            comment='User textual feedback on the evaluation',
+        ),
+    )
+    op.add_column(
+        'chat_history',
+        sa.Column(
+            'chat_source',
+            sa.String(),
+            nullable=True,
+            comment='Generic string to identify chat source (e.g. application name)',
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('chat_history', 'user_evaluation')
+    op.drop_column('chat_history', 'user_feedback')
+    op.drop_column('chat_history', 'chat_source')

--- a/brevia/chat_history.py
+++ b/brevia/chat_history.py
@@ -206,12 +206,16 @@ def get_history_query(
     """Return get history query"""
     return (
         session.query(
+            ChatHistoryStore.uuid,
             ChatHistoryStore.question,
             ChatHistoryStore.answer,
             ChatHistoryStore.session_id,
             ChatHistoryStore.cmetadata,
             ChatHistoryStore.created,
             CollectionStore.name.label('collection'),
+            ChatHistoryStore.user_evaluation,
+            ChatHistoryStore.user_feedback,
+            ChatHistoryStore.chat_source,
         )
         .join(
             CollectionStore,
@@ -224,13 +228,13 @@ def get_history_query(
 
 def history_evaluation(
     history_id: str,
-    evaluation: bool,
-    feedback: str | None = None,
+    user_evaluation: bool,
+    user_feedback: str | None = None,
 ):
     """ Update evaluation of single history item """
     with Session(db_connection()) as session:
         chat_history = session.get(ChatHistoryStore, history_id)
-        chat_history.user_evaluation = evaluation
-        chat_history.user_feedback = feedback
+        chat_history.user_evaluation = user_evaluation
+        chat_history.user_feedback = user_feedback
         session.add(chat_history)
         session.commit()

--- a/brevia/chat_history.py
+++ b/brevia/chat_history.py
@@ -230,11 +230,18 @@ def history_evaluation(
     history_id: str,
     user_evaluation: bool,
     user_feedback: str | None = None,
-):
-    """ Update evaluation of single history item """
+) -> bool:
+    """
+        Update evaluation of single history item.
+        Return false if history item is not found and true upon success.
+    """
     with Session(db_connection()) as session:
         chat_history = session.get(ChatHistoryStore, history_id)
+        if chat_history is None:
+            return False
         chat_history.user_evaluation = user_evaluation
         chat_history.user_feedback = user_feedback
         session.add(chat_history)
         session.commit()
+
+    return True

--- a/brevia/postman/Brevia API.postman_collection.json
+++ b/brevia/postman/Brevia API.postman_collection.json
@@ -1,16 +1,16 @@
 {
 	"info": {
-		"_postman_id": "484c3a34-cbf0-48a1-8d51-72bc8f460502",
+		"_postman_id": "b8d07c1e-d4fa-4b02-8759-d4ed41e1f7ce",
 		"name": "Brevia API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "4185449"
+		"_exporter_id": "234034"
 	},
 	"item": [
 		{
 			"name": "Chat",
 			"item": [
 				{
-					"name": "chat - Simple Completion",
+					"name": "chat - Basic chat",
 					"request": {
 						"auth": {
 							"type": "bearer",
@@ -299,6 +299,60 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "evaluate - Evaluate chat history item",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"try {",
+									"    tests[\"Status code is 204\"] = responseCode.code === 204;",
+									"} catch (e) {",
+									"    tests[\"Error in parsing response\"] = e;",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"uuid\": \"{{chat_history_id}}\",\n    \"user_evaluation\": false,\n    \"user_feedback\": \"Too many hallucinations! Are you high?\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/evaluate",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"evaluate"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -419,7 +473,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\": \"prova-prova-collection\",\n    \"cmetadata\": {\n        \"note\": \"note di prova\",\n        \"description\": \"descrizione di prova\"\n    }\n}",
+							"raw": "{\n    \"name\": \"{{collection}}\",\n    \"cmetadata\": {\n        \"note\": \"some notes\",\n        \"description\": \"a description\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1244,6 +1298,112 @@
 			]
 		},
 		{
+			"name": "Status",
+			"item": [
+				{
+					"name": "status - read API status",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/status",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"status"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "status - use status token",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/status?token={{status_token}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"status"
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "{{status_token}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "status - head API status",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "HEAD",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/status",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"status"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "upload_analyze - Upload file and analyze using extension",
 			"event": [
 				{
@@ -1353,74 +1513,6 @@
 					],
 					"path": [
 						"transcribe"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "status - read API status",
-			"request": {
-				"auth": {
-					"type": "bearer",
-					"bearer": [
-						{
-							"key": "token",
-							"value": "{{access_token}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"url": {
-					"raw": "{{baseUrl}}/status",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"status"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "status - head API status",
-			"request": {
-				"auth": {
-					"type": "bearer",
-					"bearer": [
-						{
-							"key": "token",
-							"value": "{{access_token}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "HEAD",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"url": {
-					"raw": "{{baseUrl}}/status",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"status"
 					]
 				}
 			},

--- a/brevia/postman/Brevia API.postman_environment.json
+++ b/brevia/postman/Brevia API.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "fcc469d4-ed0e-4ee8-b27a-ee0002dce64a",
+	"id": "3bf9c792-2899-4cc6-a8fd-bc2fcfe6d3d0",
 	"name": "Brevia API",
 	"values": [
 		{
@@ -61,9 +61,21 @@
 			"value": "what is a LLM?",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "status_token",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "chat_history_id",
+			"value": "",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-12-11T09:48:12.459Z",
-	"_postman_exported_using": "Postman/10.20.10"
+	"_postman_exported_at": "2024-01-17T17:41:34.730Z",
+	"_postman_exported_using": "Postman/10.21.11"
 }

--- a/brevia/routers/chat_history_router.py
+++ b/brevia/routers/chat_history_router.py
@@ -21,8 +21,8 @@ def read_chat_history(filter: Annotated[ChatHistoryFilter, Depends()]):
 class EvaluateBody(BaseModel):
     """ Evaluation creation model """
     uuid: str
-    evaluation: bool
-    feedback: str
+    user_evaluation: bool
+    user_feedback: str
 
 
 @router.post(
@@ -35,6 +35,6 @@ def evluate_chat_history(body: EvaluateBody):
     """ /evaluate endpoint, save chat history item user evaluation """
     history_evaluation(
         history_id=body.uuid,
-        evaluation=body.evaluation,
-        feedback=body.feedback,
+        user_evaluation=body.user_evaluation,
+        user_feedback=body.user_feedback,
     )

--- a/brevia/routers/chat_history_router.py
+++ b/brevia/routers/chat_history_router.py
@@ -1,6 +1,6 @@
 """API endpoints definitions to handle audio input"""
 from typing_extensions import Annotated
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, HTTPException, status, Depends
 from pydantic import BaseModel
 from brevia.dependencies import get_dependencies
 from brevia.chat_history import get_history, history_evaluation, ChatHistoryFilter
@@ -33,8 +33,13 @@ class EvaluateBody(BaseModel):
 )
 def evluate_chat_history(body: EvaluateBody):
     """ /evaluate endpoint, save chat history item user evaluation """
-    history_evaluation(
+    result = history_evaluation(
         history_id=body.uuid,
         user_evaluation=body.user_evaluation,
         user_feedback=body.user_feedback,
     )
+    if not result:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            f"Chat history '{body.uuid}' was not found",
+        )

--- a/brevia/routers/chat_history_router.py
+++ b/brevia/routers/chat_history_router.py
@@ -1,8 +1,9 @@
 """API endpoints definitions to handle audio input"""
 from typing_extensions import Annotated
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 from brevia.dependencies import get_dependencies
-from brevia.chat_history import get_history, ChatHistoryFilter
+from brevia.chat_history import get_history, history_evaluation, ChatHistoryFilter
 
 router = APIRouter()
 
@@ -15,3 +16,25 @@ router = APIRouter()
 def read_chat_history(filter: Annotated[ChatHistoryFilter, Depends()]):
     """ /chat_history endpoint, read stored chat history """
     return get_history(filter=filter)
+
+
+class EvaluateBody(BaseModel):
+    """ Evaluation creation model """
+    uuid: str
+    evaluation: bool
+    feedback: str
+
+
+@router.post(
+    '/evaluate',
+    status_code=204,
+    dependencies=get_dependencies(),
+    tags=['Chat'],
+)
+def evluate_chat_history(body: EvaluateBody):
+    """ /evaluate endpoint, save chat history item user evaluation """
+    history_evaluation(
+        history_id=body.uuid,
+        evaluation=body.evaluation,
+        feedback=body.feedback,
+    )

--- a/brevia/routers/collections_router.py
+++ b/brevia/routers/collections_router.py
@@ -34,7 +34,7 @@ async def read_collection(uuid: str):
 
 
 class CollectionBody(BaseModel):
-    """ summarize validation """
+    """ Collection creation model """
     name: str
     cmetadata: dict
 

--- a/tests/routers/test_chat_history_router.py
+++ b/tests/routers/test_chat_history_router.py
@@ -31,8 +31,8 @@ def test_evaluate():
     chat_hist = add_history(uuid.uuid4(), 'test_collection', 'who?', 'me')
     evaluation = {
         'uuid': str(chat_hist.uuid),
-        'evaluation': False,
-        'feedback': 'Lot of hallucinations!',
+        'user_evaluation': False,
+        'user_feedback': 'Lot of hallucinations!',
     }
     response = client.post(
         '/evaluate',
@@ -43,5 +43,5 @@ def test_evaluate():
 
     with Session(db_connection()) as session:
         history_item = session.get(ChatHistoryStore, chat_hist.uuid)
-        assert history_item.user_evaluation == evaluation['evaluation']
-        assert history_item.user_feedback == evaluation['feedback']
+        assert history_item.user_evaluation == evaluation['user_evaluation']
+        assert history_item.user_feedback == evaluation['user_feedback']

--- a/tests/routers/test_chat_history_router.py
+++ b/tests/routers/test_chat_history_router.py
@@ -45,3 +45,18 @@ def test_evaluate():
         history_item = session.get(ChatHistoryStore, chat_hist.uuid)
         assert history_item.user_evaluation == evaluation['user_evaluation']
         assert history_item.user_feedback == evaluation['user_feedback']
+
+
+def test_evaluate_failure():
+    """Test /evaluate failure"""
+    evaluation = {
+        'uuid': str(uuid.uuid4()),
+        'user_evaluation': False,
+        'user_feedback': 'Lot of hallucinations!',
+    }
+    response = client.post(
+        '/evaluate',
+        headers={'Content-Type': 'application/json'},
+        content=json.dumps(evaluation),
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
In this PR a new `/evaluate` endpoint has been introduced to allow a user to evaluate a chat reponse

Usage example: 
```http
POST /evaluate
{
  "uuid": "{{chat_history_id}}",
  "user_evaluation": false,
  "user_feedback": "Chat answer is incomprehensible",
}
```
where `{{chat_history_id}}` is the chat history record uuid.

Main changes:

* a new alembic migration to add evaluation related fields to `chat_history` table
* `/evaluate` endpoint and new `history_evaluation` function in `chat_history` module
* evaluation fields added in `GET /chat_history` response
* postman reference files updated
