### PR TITLE
Fix `qa_completion_llm` configuration usage in `/completions` endpoint

### DIFF
--- a/brevia/completions.py
+++ b/brevia/completions.py
@@ -28,7 +28,7 @@ def simple_completion_chain(
     """
 
     settings = get_settings()
-    llm_conf = settings.qa_completion_llm
+    llm_conf = settings.qa_completion_llm.copy()
     comp_llm = load_chatmodel(llm_conf)
     verbose = settings.verbose_mode
     # Create chain for follow-up question using chat history (if present)


### PR DESCRIPTION
This PR fixes a problem with `qa_completion_llm` setting in `POST /completions` API calls.
We must use a copy of `qa_completion_llm` in `load_chatmodel()` method to avoid setting change and errors on next API calls
