### PR TITLE
Use end of day and start of day in history filter

### DIFF
--- a/brevia/chat_history.py
+++ b/brevia/chat_history.py
@@ -2,7 +2,7 @@
 from typing import List
 import uuid
 import logging
-from datetime import datetime
+from datetime import datetime, time
 from langchain_community.vectorstores.pgembedding import BaseModel, CollectionStore
 from pydantic import BaseModel as PydanticModel
 import sqlalchemy
@@ -155,8 +155,15 @@ def get_history(filter: ChatHistoryFilter) -> dict:
         Read chat history with optional filters
         using pagination data in response
     """
-    max_date = datetime.now() if filter.max_date is None else filter.max_date
-    min_date = datetime.fromtimestamp(0) if filter.min_date is None else filter.min_date
+    max_date = datetime.now()
+    if filter.max_date is not None:
+        max_date = datetime.strptime(filter.max_date, '%Y-%m-%d')
+    max_date = datetime.combine(max_date, time.max)
+
+    min_date = datetime.fromtimestamp(0)
+    if filter.min_date is not None:
+        min_date = datetime.strptime(filter.min_date, '%Y-%m-%d')
+    min_date = datetime.combine(min_date, time.min)
     filter_collection = CollectionStore.name == filter.collection
     if filter.collection is None:
         filter_collection = CollectionStore.name is not None

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -62,8 +62,11 @@ def test_get_history_filters():
     create_collection('test_collection', {})
     session_id = uuid.uuid4()
     add_history(session_id, 'test_collection', 'who?', 'me')
+    today = datetime.strftime(datetime.now(), '%Y-%m-%d')
     yesterday = datetime.strftime(datetime.now() - timedelta(1), '%Y-%m-%d')
     tomorrow = datetime.strftime(datetime.now() + timedelta(1), '%Y-%m-%d')
+    result = get_history(ChatHistoryFilter(max_date=today))
+    assert result['meta']['pagination']['count'] == 1
     result = get_history(ChatHistoryFilter(min_date=yesterday))
     assert result['meta']['pagination']['count'] == 1
     result = get_history(ChatHistoryFilter(min_date=tomorrow))


### PR DESCRIPTION
This PR solves a problem using `max_date` and `min_date` query string filters in `/chat_history` 

End of day timestamp is used for `max_date` and start of day timestamp in `min_date` to include all expected history items-
