### PR TITLE
Add chat history id in `/chat` response

### DIFF
--- a/brevia/callback.py
+++ b/brevia/callback.py
@@ -10,6 +10,8 @@ from langchain.docstore.document import Document
 from langchain.schema import BaseMessage
 from langchain.schema.output import LLMResult
 from langchain.callbacks.openai_info import OpenAICallbackHandler
+from brevia.chat_history import add_history
+
 
 # Only OpenAI token usage callback handler is supported for now
 # other LLMs will always return 0 as tokens usage (for now)
@@ -72,14 +74,30 @@ class ConversationCallbackHandler(AsyncCallbackHandler):
         """Wait for conversation end"""
         await self.chain_ended.wait()  # await until event would be .set()
 
-    def chain_result(self) -> str:
-        """Return chain result"""
-        if 'source_documents' not in self.result:
-            return ''
+    def chain_result(
+        self,
+        callb: TokensCallbackHandler,
+        question: str,
+        collection: str,
+        x_chat_session: str | None = None,
+    ) -> str:
+        """Save chat history and add history id and source_documents to chain result"""
+        chat_hist = add_history(
+                session_id=x_chat_session,
+                collection=collection,
+                question=question,
+                answer=self.result['answer'].strip(" \n"),
+                metadata=token_usage(callb),
+        )
 
-        docs = []
-        for doc in self.result['source_documents']:
-            docs.append({'page_content': doc.page_content, 'metadata': doc.metadata})
+        docs = [{'chat_history_id': None if chat_hist is None else str(chat_hist.uuid)}]
+
+        if 'source_documents' in self.result:
+            for doc in self.result['source_documents']:
+                docs.append({
+                    'page_content': doc.page_content,
+                    'metadata': doc.metadata
+                })
 
         return json.dumps(docs)
 

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,0 +1,28 @@
+"""Callback module tests"""
+from uuid import uuid4
+from json import loads
+from langchain.docstore.document import Document
+from brevia.callback import ConversationCallbackHandler, TokensCallbackHandler
+from brevia.collections import create_collection
+
+
+def test_chain_result():
+    """Test chain_result method"""
+    callback = ConversationCallbackHandler()
+    callback.result = {
+        'answer': 'I don\'t know',
+        'source_documents': [Document(page_content='', metadata={})],
+    }
+    create_collection('new_collection', {})
+    result = callback.chain_result(
+        callb=TokensCallbackHandler(),
+        collection='new_collection',
+        question='who are you?',
+        x_chat_session=uuid4(),
+
+    )
+    assert result is not None
+    item = loads(result)
+    assert len(item) == 2
+    assert 'chat_history_id' in item[0]
+    assert 'page_content' in item[1]


### PR DESCRIPTION
This PR adds `chat_history_id` of the last `question`/`answer` in a chat action to be used for a user evaluation (via `POST /evaluation`)

* in case of streaming chat an item with `chat_history_id` is appended in streaming response content 
* if no streaming is requested a new `chat_history_id` field will appear in chat response 
