### PR TITLE
New `/index/{id}` and `/index/{id}/documents_metadata` endpoints

### DIFF
--- a/brevia/chat_history.py
+++ b/brevia/chat_history.py
@@ -1,6 +1,5 @@
 """Chat history table & utilities"""
 from typing import List
-import uuid
 import logging
 from datetime import datetime, time
 from langchain_community.vectorstores.pgembedding import BaseModel, CollectionStore
@@ -13,6 +12,7 @@ from brevia.connection import db_connection
 from brevia.models import load_embeddings
 from brevia.settings import get_settings
 from brevia.utilities.json_api import query_data_pagination
+from brevia.utilities.uuid import is_valid_uuid
 
 
 class ChatHistoryStore(BaseModel):
@@ -130,15 +130,6 @@ def add_history(
         session.commit()
 
         return chat_history_store
-
-
-def is_valid_uuid(val) -> bool:
-    """ Check UUID validity """
-    try:
-        uuid.UUID(str(val))
-        return True
-    except (ValueError, TypeError):
-        return False
 
 
 class ChatHistoryFilter(PydanticModel):

--- a/brevia/collections.py
+++ b/brevia/collections.py
@@ -2,6 +2,7 @@
 from langchain_community.vectorstores.pgembedding import CollectionStore
 from sqlalchemy.orm import Session
 from brevia import connection
+from brevia.utilities.uuid import is_valid_uuid
 
 
 def collections_info(collection: str | None = None):
@@ -43,6 +44,8 @@ def collection_exists(uuid: str) -> bool:
 
 def single_collection(uuid: str) -> (CollectionStore | None):
     """ Get single collection by UUID """
+    if not is_valid_uuid(uuid):
+        return None
     with Session(connection.db_connection()) as session:
         return session.get(CollectionStore, uuid)
 

--- a/brevia/index.py
+++ b/brevia/index.py
@@ -119,3 +119,27 @@ def update_metadata(
         query = session.query(EmbeddingStore).filter(filter_collection, filter_document)
         query.update({EmbeddingStore.cmetadata: metadata})
         session.commit()
+
+
+def documents_metadata(
+    collection_id: str,
+    filter: dict[str, str] = {},
+):
+    """ Read documents metadata of a collection"""
+    filter_collection = EmbeddingStore.collection_id == collection_id
+    with Session(connection.db_connection()) as session:
+        query = session.query(EmbeddingStore.custom_id, EmbeddingStore.cmetadata)
+        query = query.filter(filter_collection)
+        for key in filter.keys():
+            query = query.filter(
+                EmbeddingStore.cmetadata[key].astext == str(filter[key])
+            )
+        result = []
+        docs = []
+        for row in query.all():
+            item = row._asdict()
+            if (item['custom_id'] not in docs):
+                docs.append(item['custom_id'])
+                result.append(item)
+
+        return result

--- a/brevia/index.py
+++ b/brevia/index.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from brevia import connection, load_file
 from brevia.models import load_embeddings
 from brevia.settings import get_settings
+from brevia.utilities.json_api import query_data_pagination
 
 
 def init_index():
@@ -107,6 +108,33 @@ def read_document(
         return [row._asdict() for row in query.all()]
 
 
+def metadata_filters(filter: dict[str, str] = {}):
+    """Returns a list of metadata filters in embeddings table to be use as query filter"""
+    res = []
+    for key in filter.keys():
+        res.append(EmbeddingStore.cmetadata[key].astext == str(filter[key]))
+    return res
+
+
+def collection_documents(
+    collection_id: str,
+    filter: dict[str, str] = {},
+    page: int = 1,
+    page_size: int = 50,
+):
+    """ Read document `document_id` from collection index"""
+    query_filters = [EmbeddingStore.collection_id == collection_id]
+    query_filters.extend(metadata_filters(filter=filter))
+    with Session(connection.db_connection()) as session:
+        query = session.query(
+            EmbeddingStore.document,
+            EmbeddingStore.cmetadata,
+            EmbeddingStore.custom_id
+        )
+        query = query.filter(*query_filters)
+        return query_data_pagination(query=query, page=page, page_size=page_size)
+
+
 def update_metadata(
     collection_id: str,
     document_id: str,
@@ -126,14 +154,11 @@ def documents_metadata(
     filter: dict[str, str] = {},
 ):
     """ Read documents metadata of a collection"""
-    filter_collection = EmbeddingStore.collection_id == collection_id
+    query_filters = [EmbeddingStore.collection_id == collection_id]
+    query_filters.extend(metadata_filters(filter=filter))
     with Session(connection.db_connection()) as session:
         query = session.query(EmbeddingStore.custom_id, EmbeddingStore.cmetadata)
-        query = query.filter(filter_collection)
-        for key in filter.keys():
-            query = query.filter(
-                EmbeddingStore.cmetadata[key].astext == str(filter[key])
-            )
+        query = query.filter(*query_filters)
         result = []
         docs = []
         for row in query.all():

--- a/brevia/index.py
+++ b/brevia/index.py
@@ -109,7 +109,9 @@ def read_document(
 
 
 def metadata_filters(filter: dict[str, str] = {}):
-    """Returns a list of metadata filters in embeddings table to be use as query filter"""
+    """
+        Returns a list of metadata to be use as query filter in embeddings table
+    """
     res = []
     for key in filter.keys():
         res.append(EmbeddingStore.cmetadata[key].astext == str(filter[key]))

--- a/brevia/postman/Brevia API.postman_collection.json
+++ b/brevia/postman/Brevia API.postman_collection.json
@@ -473,7 +473,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\": \"{{collection}}\",\n    \"cmetadata\": {\n        \"note\": \"some notes\",\n        \"description\": \"a description\"\n    }\n}",
+							"raw": "{\n    \"name\": \"{{collection}}\",\n    \"cmetadata\": {\n        \"title\": \"collection title\",\n        \"description\": \"a description\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -550,7 +550,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\": \"nuovo-nome-nuovo\",\n    \"cmetadata\": {\n        \"note\": \"note di prova prova\",\n        \"description\": \"descrizione di prova prova\"\n    }\n}",
+							"raw": "{\n    \"name\": \"{{collection}}\",\n    \"cmetadata\": {\n        \"title\": \"brand new title\",\n        \"description\": \"brand new description\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -633,7 +633,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"content\" : \"Lorem ipsum dolor sit amet, consectetur adipisci elit, sed do eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrum exercitationem ullamco laboriosam, nisi ut aliquid ex ea commodi consequatur. Duis aute irure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\",\r\n    \"collection_id\" : \"{{collection_id}}\",\r\n    \"document_id\" : \"{{document_id}}\",\r\n    \"metadata\" : {\"category\": \"cat1\"}\r\n}"
+							"raw": "{\r\n    \"content\" : \"Lorem ipsum dolor sit amet, consectetur adipisci elit, sed do eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrum exercitationem ullamco laboriosam, nisi ut aliquid ex ea commodi consequatur. Duis aute irure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\",\r\n    \"collection_id\" : \"{{collection_id}}\",\r\n    \"document_id\" : \"{{document_id}}\",\r\n    \"metadata\" : {\"type\": \"questions\"}\r\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/index",
@@ -772,6 +772,165 @@
 								"index",
 								"{{collection_id}}",
 								"{{document_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "index - Read documents metadata in a collection",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/index/{{collection_id}}/documents_metadata",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"index",
+								"{{collection_id}}",
+								"documents_metadata"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "index - Read documents metadata in a collection with filter",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/index/{{collection_id}}/documents_metadata?filter[type]=questions",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"index",
+								"{{collection_id}}",
+								"documents_metadata"
+							],
+							"query": [
+								{
+									"key": "filter[type]",
+									"value": "questions"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "index - Read documents in a collection",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/index/{{collection_id}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"index",
+								"{{collection_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "index - Read documents in a collection with filter and pagination",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/index/{{collection_id}}/?filter[type]=questions&page_size=15",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"index",
+								"{{collection_id}}",
+								""
+							],
+							"query": [
+								{
+									"key": "filter[type]",
+									"value": "questions"
+								},
+								{
+									"key": "page_size",
+									"value": "15"
+								}
 							]
 						}
 					},

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -148,7 +148,12 @@ def read_filter(request: Request) -> dict:
     dependencies=get_dependencies(json_content_type=False),
     tags=['Index'],
 )
-def index_docs(collection_id: str, request: Request, page: int = 1, page_size: int = 50):
+def index_docs(
+    collection_id: str,
+    request: Request,
+    page: int = 1,
+    page_size: int = 50
+):
     """ Read collection documents with metadata filter """
     load_collection(collection_id=collection_id)
     return index.collection_documents(

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -120,6 +120,27 @@ def remove_document(collection_id: str, document_id: str):
 
 
 @router.get(
+    '/index/{collection_id}/documents_metadata',
+    dependencies=get_dependencies(json_content_type=False),
+    tags=['Index'],
+)
+def index_docs_metadata(collection_id: str, filter: str = '{}'):
+    """ Read collection documents metadata"""
+    try:
+        filter = json.loads(filter)
+    except ValueError:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Bad 'filter' query string",
+        )
+
+    return index.documents_metadata(
+        collection_id=collection_id,
+        filter=filter
+    )
+
+
+@router.get(
     '/index/{collection_id}/{document_id}',
     dependencies=get_dependencies(json_content_type=False),
     tags=['Index'],

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -119,6 +119,32 @@ def remove_document(collection_id: str, document_id: str):
     )
 
 
+def read_metadata_filter(input: str):
+    """ Read metadata filter from a string and decodes it"""
+    try:
+        return json.loads(input)
+    except ValueError as exc:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Bad 'filter' query string",
+        ) from exc
+
+
+@router.get(
+    '/index/{collection_id}',
+    dependencies=get_dependencies(json_content_type=False),
+    tags=['Index'],
+)
+def index_docs(collection_id: str, filter: str = '{}', page: str = '1', page_size: str = '50'):
+    """ Read collection documents with metadata filter """
+    return index.collection_documents(
+        collection_id=collection_id,
+        filter=read_metadata_filter(filter),
+        page=int(page),
+        page_size=int(page_size)
+    )
+
+
 @router.get(
     '/index/{collection_id}/documents_metadata',
     dependencies=get_dependencies(json_content_type=False),
@@ -126,17 +152,9 @@ def remove_document(collection_id: str, document_id: str):
 )
 def index_docs_metadata(collection_id: str, filter: str = '{}'):
     """ Read collection documents metadata"""
-    try:
-        filter = json.loads(filter)
-    except ValueError:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            "Bad 'filter' query string",
-        )
-
     return index.documents_metadata(
         collection_id=collection_id,
-        filter=filter
+        filter=read_metadata_filter(filter)
     )
 
 

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -120,17 +120,6 @@ def remove_document(collection_id: str, document_id: str):
     )
 
 
-def read_metadata_filter(input: str):
-    """ Read metadata filter from a string and decodes it"""
-    try:
-        return json.loads(input)
-    except ValueError as exc:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            "Bad 'filter' query string",
-        ) from exc
-
-
 def read_filter(request: Request) -> dict:
     """Read metadata filter dict from query string"""
     result = {}

--- a/brevia/utilities/json_api.py
+++ b/brevia/utilities/json_api.py
@@ -1,0 +1,29 @@
+"""Utility functions to format sqlalchemy query data as JSON API."""
+from sqlalchemy.orm import Query
+
+
+def query_data_pagination(query: Query, page: int = 1, page_size: int = 50):
+    """
+        Format query data with pagination
+    """
+    page = max(1, page)  # min page number is 1
+    page_size = min(1000, page_size)  # max page size is 1000
+    offset = (page - 1) * page_size
+
+    count = query.count()
+    results = [u._asdict() for u in query.offset(offset).limit(page_size).all()]
+    pcount = int(count / page_size)
+    pcount += 0 if (count % page_size) == 0 else 1
+
+    return {
+        'data': results,
+        'meta': {
+            'pagination': {
+                'count': count,
+                'page': page,
+                'page_count': pcount,
+                'page_items': len(results),
+                'page_size': page_size,
+            },
+        }
+    }

--- a/brevia/utilities/uuid.py
+++ b/brevia/utilities/uuid.py
@@ -1,0 +1,11 @@
+"""UUID utility functions"""
+import uuid
+
+
+def is_valid_uuid(val) -> bool:
+    """ Check UUID validity """
+    try:
+        uuid.UUID(str(val))
+        return True
+    except (ValueError, TypeError):
+        return False


### PR DESCRIPTION
This PR introduces two new collection index endpoints:

* `GET /index/{collection_id}`: returns a paginated list of documents indexed in a collection; each item corresponds to a `pg_embeddings` record, so you can get usually more items for the same document 
* `GET /index/{collection_id}/documents_metadata`: returns a list of documents metadata in a collection, so you will get unique items with `cmetadata` and `custom_id` (alias for document id in brevia) 
* both endpoints come with a `filter` query string on metadata to allow filters on specific metadata keys and values 

Example:

```http
GET /index/{collection_id}?filter[type]=questions
```
Will return all items having `"type": "questions"` key/value in `cmetadata` 

```http
GET /index/{collection_id}/index_metadata?filter[type]=files&filter[category]=books
```
Will return all documents metadata having `"type": "files"` and `"category":"books"` key/value pairs in `cmetadata`
 
 