### PR TITLE
New `/index/link` endpoint: index web page via link

### DIFF
--- a/brevia/load_file.py
+++ b/brevia/load_file.py
@@ -100,6 +100,17 @@ def read(
     return read_txt_file(file_path=file_path)
 
 
+def read_url(
+    url: str,
+    **loader_kwargs: Any,
+) -> str:
+    """
+    Load text from a web page URL
+    """
+    loader = BSHTMLLoader(url=url, **loader_kwargs)
+    return cleanup_text(loader.load().page_content)
+
+
 def load_documents(file_path: str, **kwargs: Any) -> List[Document]:
     """Load documents from a file or folder path"""
     mtype = mimetypes.guess_type(file_path)[0]

--- a/brevia/load_file.py
+++ b/brevia/load_file.py
@@ -103,12 +103,12 @@ def read(
     return read_txt_file(file_path=file_path)
 
 
-def read_url(
+def read_html_url(
     url: str,
     **loader_kwargs: Any,
 ) -> str:
     """
-    Load text from a web page URL
+    Load text from HTML content of web page URL
     """
     temp_file = tempfile.NamedTemporaryFile(delete=False)
     response = requests.get(url)

--- a/brevia/postman/Brevia API.postman_collection.json
+++ b/brevia/postman/Brevia API.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "1d8389da-8d33-46ee-8b7c-f75f35ea302b",
+		"_postman_id": "b8d07c1e-d4fa-4b02-8759-d4ed41e1f7ce",
 		"name": "Brevia API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "4185449"
+		"_exporter_id": "234034"
 	},
 	"item": [
 		{
@@ -784,6 +784,46 @@
 							"path": [
 								"index",
 								"upload"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "index/link - Index a webpage via link",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"link\" : \"{{link}}\",\n    \"collection_id\" : \"{{collection_id}}\",\n    \"document_id\" : \"{{document_id}}\",\n    \"metadata\" : {\"type\": \"links\"}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/index/link",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"index",
+								"link"
 							]
 						}
 					},

--- a/brevia/postman/Brevia API.postman_environment.json
+++ b/brevia/postman/Brevia API.postman_environment.json
@@ -73,9 +73,15 @@
 			"value": "",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "link",
+			"value": "",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2024-01-17T17:41:34.730Z",
-	"_postman_exported_using": "Postman/10.21.11"
+	"_postman_exported_at": "2024-03-04T10:48:24.932Z",
+	"_postman_exported_using": "Postman/10.20.10"
 }

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -106,6 +106,52 @@ def upload_and_index(
     )
 
 
+class IndexLink(BaseModel):
+    """ /index request body """
+    link: str  # link to a webpage
+    collection_id: str
+    document_id: str
+    metadata: dict = {}
+    options: dict = {}
+
+
+@router.post(
+    '/index/link',
+    status_code=204,
+    dependencies=get_dependencies(json_content_type=False),
+    tags=['Index'],
+)
+def parse_link_and_index(item: IndexLink):
+    """
+    Add a web page content to a collection index
+    """
+    collection = load_collection(collection_id=item.collection_id)
+    log = logging.getLogger(__name__)
+    log.info(
+        "Adding link '%s' to collection '%s' / document '%s'",
+        item.link,
+        collection.name,
+        item.document_id
+    )
+
+    text = load_file.read_url(url=item.link, **item.options)
+    if not text:
+        return
+    # remove same document if already indexed
+    index.remove_document(
+        collection_id=collection.id,
+        document_id=item.document_id,
+    )
+    index.add_document(
+        document=Document(
+            page_content=text,
+            metadata=item.metadata,
+        ),
+        collection_name=collection.name,
+        document_id=item.document_id,
+    )
+
+
 @router.delete(
     '/index/{collection_id}/{document_id}',
     status_code=204,

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -107,7 +107,7 @@ def upload_and_index(
 
 
 class IndexLink(BaseModel):
-    """ /index request body """
+    """ /index/link request body """
     link: str  # link to a webpage
     collection_id: str
     document_id: str
@@ -134,7 +134,7 @@ def parse_link_and_index(item: IndexLink):
         item.document_id
     )
 
-    text = load_file.read_url(url=item.link, **item.options)
+    text = load_file.read_html_url(url=item.link, **item.options)
     if not text:
         return
     # remove same document if already indexed

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -139,7 +139,7 @@ def parse_link_and_index(item: IndexLink):
         return
     # remove same document if already indexed
     index.remove_document(
-        collection_id=collection.id,
+        collection_id=item.collection_id,
         document_id=item.document_id,
     )
     index.add_document(

--- a/tests/routers/test_index_router.py
+++ b/tests/routers/test_index_router.py
@@ -8,6 +8,7 @@ from langchain.docstore.document import Document
 from brevia.routers import index_router
 from brevia.collections import create_collection
 from brevia.index import add_document, read_document
+from unittest.mock import patch
 
 app = FastAPI()
 app.include_router(index_router.router)
@@ -134,6 +135,52 @@ def test_upload_analyze_fail():
         },
     )
     assert response.status_code == 400
+
+
+@patch('brevia.routers.index_router.load_file.requests.get')
+def test_index_link(mock_get):
+    """Test POST /index/link endpoint"""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.text = 'Lorem Ipsum'
+    collection = create_collection('test_collection', {})
+    response = client.post(
+        '/index/link',
+        headers={'Content-Type': 'application/json'},
+        content=json.dumps({
+            'link': 'https://www.example.com',
+            'collection_id': str(collection.uuid),
+            'document_id': '123',
+            'metadata': {'type': 'links'},
+        })
+    )
+    assert response.status_code == 204
+    assert response.text == ''
+    docs = read_document(collection_id=str(collection.uuid), document_id='123')
+    assert len(docs) == 1
+    assert docs[0].get('cmetadata') == {'type': 'links'}
+    assert docs[0].get('document') == 'Lorem Ipsum'
+
+
+@patch('brevia.routers.index_router.load_file.requests.get')
+def test_index_link_empty(mock_get):
+    """Test POST /index/link endpoint with empty or missing response"""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.text = ''
+    collection = create_collection('test_collection', {})
+    response = client.post(
+        '/index/link',
+        headers={'Content-Type': 'application/json'},
+        content=json.dumps({
+            'link': 'https://www.example.com',
+            'collection_id': str(collection.uuid),
+            'document_id': '123',
+            'metadata': {'type': 'links'},
+        })
+    )
+    assert response.status_code == 204
+    assert response.text == ''
+    docs = read_document(collection_id=str(collection.uuid), document_id='123')
+    assert len(docs) == 0
 
 
 def test_index_metadata_document():

--- a/tests/routers/test_index_router.py
+++ b/tests/routers/test_index_router.py
@@ -162,6 +162,31 @@ def test_index_link(mock_get):
 
 
 @patch('brevia.routers.index_router.load_file.requests.get')
+def test_index_link_selector(mock_get):
+    """Test POST /index/link endpoint with 'selector' option filer"""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.text = '<h1>Lorem Ipsum</h1><p class="test">Some text</p>'
+    collection = create_collection('test_collection', {})
+    response = client.post(
+        '/index/link',
+        headers={'Content-Type': 'application/json'},
+        content=json.dumps({
+            'link': 'https://www.example.com',
+            'collection_id': str(collection.uuid),
+            'document_id': '123',
+            'metadata': {'type': 'links'},
+            'options': {'selector': 'p.test'},
+        })
+    )
+    assert response.status_code == 204
+    assert response.text == ''
+    docs = read_document(collection_id=str(collection.uuid), document_id='123')
+    assert len(docs) == 1
+    assert docs[0].get('cmetadata') == {'type': 'links'}
+    assert docs[0].get('document') == 'Some text'
+
+
+@patch('brevia.routers.index_router.load_file.requests.get')
 def test_index_link_empty(mock_get):
     """Test POST /index/link endpoint with empty or missing response"""
     mock_get.return_value.status_code = 200


### PR DESCRIPTION
This PR introduces a new endpoint - `POST /index/link` to index a web page in a collection providing the web page link

New endpoint signature example:

```http
POST /index/link
{
   "link": "https:/www.example.com/my-page",
   "collection_id": "############",
   "document_id": "123",
   "metadata": {"type": "links", "category": "one"},
   "options": {"selector": ".content"}
}
```

Where in the optional `options` field you may provide some rules to filter the HTML page. In this case tags within a `content` class will be extracted. 

A new `load_file.read_html_url` method has been added to HTML load file content from a remote URL and provide optional filters with selector rules
