### PR TITLE
New `update_collection_links` command

### DIFF
--- a/brevia/commands.py
+++ b/brevia/commands.py
@@ -46,6 +46,7 @@ def db_downgrade_cmd(revision):
     """Revert to a previous database revision"""
     downgrade(revision)
 
+
 @init_command
 @click.command()
 @click.option("-f", "--file-path", required=True, help="File or folder path")

--- a/brevia/commands.py
+++ b/brevia/commands.py
@@ -11,19 +11,13 @@ from brevia.tokens import create_token
 from brevia.utilities.openapi import brevia_openapi
 
 
-def init_command(func):
-    """Initialization decorator for command functions"""
-    def wrapper():
-        # initialize logging from optional log.ini
-        log_ini_path = f'{getcwd()}/log.ini'
-        if path.exists(log_ini_path):
-            config.fileConfig(log_ini_path)
-        func()
-
-    return wrapper
+def init_logging():
+    # initialize logging from optional log.ini
+    log_ini_path = f'{getcwd()}/log.ini'
+    if path.exists(log_ini_path):
+        config.fileConfig(log_ini_path)
 
 
-@init_command
 @click.command()
 @click.option("-v", "--verbose", is_flag=True, default=False, help="Verbose mode")
 def db_current_cmd(verbose):
@@ -31,7 +25,6 @@ def db_current_cmd(verbose):
     current(verbose)
 
 
-@init_command
 @click.command()
 @click.option("-r", "--revision", default="head", help="Revision target")
 def db_upgrade_cmd(revision):
@@ -39,7 +32,6 @@ def db_upgrade_cmd(revision):
     upgrade(revision)
 
 
-@init_command
 @click.command()
 @click.option("-r", "--revision", required=True, help="Revision target")
 def db_downgrade_cmd(revision):
@@ -47,7 +39,6 @@ def db_downgrade_cmd(revision):
     downgrade(revision)
 
 
-@init_command
 @click.command()
 @click.option("-f", "--file-path", required=True, help="File or folder path")
 @click.option("-c", "--collection", required=True, help="Collection name")
@@ -76,7 +67,6 @@ def import_file(file_path: str, collection: str, options: str = ''):
 #   file_path: /path/to/file
 #   param1: value1
 #   param2: value2
-@init_command
 @click.command()
 @click.option("-n", "--num", default=1, help="Number of attempts")
 @click.option(
@@ -92,7 +82,6 @@ def run_test_service(num: int = 1, file_path: str = f'{getcwd()}/test_service.ym
     run_service.run_service_from_yaml(file_path=file_path, num_attempts=num)
 
 
-@init_command
 @click.command()
 @click.option("-c", "--collection", required=True, help="Collection name")
 @click.option(
@@ -109,7 +98,6 @@ def export_collection(folder_path: str, collection: str):
     )
 
 
-@init_command
 @click.command()
 @click.option("-c", "--collection", required=True, help="Collection name")
 @click.option(
@@ -126,7 +114,6 @@ def import_collection(folder_path: str, collection: str):
     )
 
 
-@init_command
 @click.command()
 @click.option("-u", "--user", default="brevia", help="Token user name")
 @click.option("-d", "--duration", default=60, help="Token duration in minutes")
@@ -136,7 +123,6 @@ def create_access_token(user: str, duration: int):
     print(token)
 
 
-@init_command
 @click.command()
 @click.option(
     "-f",
@@ -159,9 +145,10 @@ def create_openapi(file_path: str, output: str):
         json.dump(metadata, f)
 
 
-@init_command
 @click.command()
 @click.option("-c", "--collection", required=True, help="Collection name")
 def update_collection_links(collection: str):
     """Update index documents of a collection having `"type": "links"` in metadata."""
-    update_links_documents(collection_name=collection)
+    init_logging()
+    num = update_links_documents(collection_name=collection)
+    print(f'Updated {num} links documents. Done!')

--- a/brevia/index.py
+++ b/brevia/index.py
@@ -1,11 +1,14 @@
 """Index document with embeddings in vector database."""
 from os import path
+from logging import getLogger
 from langchain.docstore.document import Document
 from langchain.text_splitter import NLTKTextSplitter
 from langchain.vectorstores.pgvector import PGVector
+from langchain_community.vectorstores.pgembedding import CollectionStore
 from langchain_community.vectorstores.pgembedding import EmbeddingStore
 from sqlalchemy.orm import Session
 from brevia import connection, load_file
+from brevia.collections import single_collection_by_name
 from brevia.models import load_embeddings
 from brevia.settings import get_settings
 from brevia.utilities.json_api import query_data_pagination
@@ -63,14 +66,7 @@ def add_document(
     document_id: str = None,
 ) -> int:
     """ Add document to index and return number of splitted text chunks"""
-    settings = get_settings()
-    text_splitter = NLTKTextSplitter(
-        separator="\n",
-        chunk_size=settings.text_chunk_size,
-        chunk_overlap=settings.text_chunk_overlap
-    )
-    texts = text_splitter.split_documents([document])
-
+    texts = split_document(document)
     PGVector.from_documents(
         embedding=load_embeddings(),
         documents=texts,
@@ -80,6 +76,22 @@ def add_document(
     )
 
     return len(texts)
+
+
+def split_document(document: Document):
+    """ Split document into text chunks and return a list of documents"""
+    settings = get_settings()
+    text_splitter = NLTKTextSplitter(
+        separator="\n",
+        chunk_size=settings.text_chunk_size,
+        chunk_overlap=settings.text_chunk_overlap
+    )
+    texts = text_splitter.split_documents([document])
+    counter = 1
+    for text in texts:
+        text.metadata['part'] = counter
+        counter += 1
+    return texts
 
 
 def remove_document(
@@ -170,3 +182,73 @@ def documents_metadata(
                 result.append(item)
 
         return result
+
+
+def update_links_documents(collection_name: str):
+    """ Update links document contents of a collection, if changed"""
+    log = getLogger(__file__)
+    log.info('Updating links contents in "%s"', collection_name)
+    collection = single_collection_by_name(collection_name)
+    if collection is None:
+        log.error('Collection "%s" not found', collection_name)
+        return
+    docs_meta = documents_metadata(collection_id=collection.uuid,
+                                   filter={'type': 'links'})
+    for doc in docs_meta:
+        update_collection_link(
+            collection=collection,
+            document_id=doc['custom_id'],
+            document_medatata=doc['cmetadata']
+        )
+
+
+def update_collection_link(collection: CollectionStore, document_id: str,
+                           document_medatata: dict):
+    """ Update a document link in a collection"""
+    log = getLogger(__file__)
+    url = document_medatata.get('url')
+    if not url:
+        log.error('Document "%s" has no URL metadata', document_id)
+        return
+
+    options = select_load_link_options(
+        url=url,
+        link_load_options=collection.cmetadata.get('link_load_options', [])
+    )
+    text = load_file.read_html_url(url=url, **options)
+    document = Document(page_content=text, metadata=document_medatata)
+    if document_has_changed(document=document, collection_id=collection.uuid,
+                            document_id=document_id):
+        remove_document(collection_id=collection.uuid, document_id=document_id)
+        add_document(document=document, collection_name=collection.name,
+                     document_id=document_id)
+
+
+def document_has_changed(document: Document, collection_id: str, document_id: str):
+    """ Check if a document has changed """
+    stored_docs = read_document(collection_id=collection_id, document_id=document_id)
+    stored_docs.sort(key=lambda x: x['cmetadata'].get('part', 0))
+
+    splitted = split_document(document)
+    if len(stored_docs) != len(splitted):
+        return True
+    for i, stored_doc in enumerate(stored_docs):
+        if stored_doc['document'] != splitted[i].page_content:
+            return True
+        if stored_doc['cmetadata'] != splitted[i].metadata:
+            return True
+
+    return False
+
+
+def select_load_link_options(url: str, link_load_options: list):
+    """ Select load link options for a given URL"""
+    item = next((x for x in link_load_options if url == x['url']), None)
+    if item:
+        return {'selector': item.get('selector', '')}
+
+    item = next((x for x in link_load_options if url.startswith(x['url'])), None)
+    if item:
+        return {'selector': item.get('selector', '')}
+
+    return {}

--- a/brevia/index.py
+++ b/brevia/index.py
@@ -177,7 +177,7 @@ def documents_metadata(
         docs = []
         for row in query.all():
             item = row._asdict()
-            if (item['custom_id'] not in docs):
+            if item['custom_id'] not in docs:
                 docs.append(item['custom_id'])
                 result.append(item)
 

--- a/brevia/load_file.py
+++ b/brevia/load_file.py
@@ -2,10 +2,10 @@
 import os
 import re
 import mimetypes
-import requests
 import tempfile
-from bs4 import BeautifulSoup
 from typing import List, Any
+import requests
+from bs4 import BeautifulSoup
 from langchain.docstore.document import Document
 from langchain.document_loaders import (
     BSHTMLLoader,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ repository = "https://github.com/brevia-ai/brevia"
   import_collection = "brevia.commands:import_collection"
   import_file = "brevia.commands:import_file"
   test_service = "brevia.commands:run_test_service"
+  update_collection_links = "brevia.commands:update_collection_links"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^6.1.0"

--- a/tests/routers/test_index_router.py
+++ b/tests/routers/test_index_router.py
@@ -64,7 +64,7 @@ def test_get_index_document():
     assert response.status_code == 200
     data = response.json()
     assert data is not None
-    assert data == [{'document': 'Lorem Ipsum', 'cmetadata': {}}]
+    assert data == [{'document': 'Lorem Ipsum', 'cmetadata': {'part': 1}}]
 
 
 def test_delete_document_index():
@@ -157,7 +157,7 @@ def test_index_link(mock_get):
     assert response.text == ''
     docs = read_document(collection_id=str(collection.uuid), document_id='123')
     assert len(docs) == 1
-    assert docs[0].get('cmetadata') == {'type': 'links'}
+    assert docs[0].get('cmetadata') == {'type': 'links', 'part': 1}
     assert docs[0].get('document') == 'Lorem Ipsum'
 
 
@@ -182,7 +182,7 @@ def test_index_link_selector(mock_get):
     assert response.text == ''
     docs = read_document(collection_id=str(collection.uuid), document_id='123')
     assert len(docs) == 1
-    assert docs[0].get('cmetadata') == {'type': 'links'}
+    assert docs[0].get('cmetadata') == {'type': 'links', 'part': 1}
     assert docs[0].get('document') == 'Some text'
 
 
@@ -244,7 +244,7 @@ def test_get_index_collection():
     assert 'data' in data
     assert data['data'] == [{
         'document': 'Lorem Ipsum',
-        'cmetadata': {'type': 'documents'},
+        'cmetadata': {'type': 'documents', 'part': 1},
         'custom_id': '123'
     }]
 
@@ -269,11 +269,11 @@ def test_get_index_documents_metadata():
     data = response.json()
     assert data == [
         {
-            'cmetadata': {'type': 'documents'},
+            'cmetadata': {'type': 'documents', 'part': 1},
             'custom_id': '123'
         },
         {
-            'cmetadata': {'type': 'questions'},
+            'cmetadata': {'type': 'questions', 'part': 1},
             'custom_id': '456'
         },
     ]
@@ -283,7 +283,7 @@ def test_get_index_documents_metadata():
     assert response.status_code == 200
     data = response.json()
     assert data == [{
-        'cmetadata': {'type': 'questions'},
+        'cmetadata': {'type': 'questions', 'part': 1},
         'custom_id': '456'
     }]
 
@@ -292,6 +292,6 @@ def test_get_index_documents_metadata():
     assert response.status_code == 200
     data = response.json()
     assert data == [{
-        'cmetadata': {'type': 'documents'},
+        'cmetadata': {'type': 'documents', 'part': 1},
         'custom_id': '123'
     }]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -13,9 +13,12 @@ from brevia.commands import (
     run_test_service,
     create_access_token,
     create_openapi,
+    update_collection_links,
 )
 from brevia.collections import create_collection, collection_name_exists
 from brevia.settings import get_settings
+from brevia.index import add_document
+from langchain.docstore.document import Document
 
 
 def test_db_current_cmd():
@@ -128,3 +131,16 @@ def test_create_openapi():
     assert result.exit_code == 0
     assert exists(output_path)
     unlink(output_path)
+
+
+def test_update_collection_links():
+    """ Test update_collection_links function """
+    collection = create_collection('test', {})
+    doc1 = Document(page_content='some', metadata={'type': 'links', 'url': 'https://example.com'})
+    add_document(document=doc1, collection_name='test')
+    runner = CliRunner()
+    result = runner.invoke(update_collection_links, [
+        '--collection',
+        collection.name,
+    ])
+    assert result.exit_code == 0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -136,7 +136,8 @@ def test_create_openapi():
 def test_update_collection_links():
     """ Test update_collection_links function """
     collection = create_collection('test', {})
-    doc1 = Document(page_content='some', metadata={'type': 'links', 'url': 'https://example.com'})
+    doc1 = Document(page_content='some',
+                    metadata={'type': 'links', 'url': 'https://example.com'})
     add_document(document=doc1, collection_name='test')
     runner = CliRunner()
     result = runner.invoke(update_collection_links, [

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,8 +1,12 @@
 """Index module tests"""
 from pathlib import Path
 import pytest
-from brevia.index import load_pdf_file
+from brevia.index import (
+    load_pdf_file, update_links_documents,
+    add_document, document_has_changed, select_load_link_options
+)
 from brevia.collections import create_collection
+from langchain.docstore.document import Document
 
 
 def test_load_pdf_file():
@@ -19,3 +23,46 @@ def test_load_pdf_file_fail():
     with pytest.raises(FileNotFoundError) as exc:
         load_pdf_file(file_path=file_path, collection_name='test')
     assert str(exc.value) == file_path
+
+
+def test_update_links_documents():
+    """Test update_links_documents method with zero results"""
+    result = update_links_documents('test')
+    assert result == 0
+
+    create_collection('test', {})
+    doc1 = Document(page_content='some', metadata={'type': 'links'})
+    add_document(document=doc1, collection_name='test')
+    result = update_links_documents('test')
+    assert result == 0
+
+
+def test_document_has_changed():
+    """Test document_has_changed method"""
+    collection = create_collection('test', {})
+
+    doc1 = Document(page_content='some', metadata={})
+    add_document(document=doc1, collection_name='test', document_id='1')
+    result = document_has_changed(doc1, collection.uuid, '1')
+    assert result is False
+
+    doc1.metadata = {'type': 'links'}
+    result = document_has_changed(doc1, collection.uuid, '1')
+    assert result is True
+
+    add_document(document=Document(page_content='another'), collection_name='test', document_id='1')
+    result = document_has_changed(doc1, collection.uuid, '1')
+    assert result is True
+
+
+def test_select_load_link_options():
+    """Test select_load_link_options method"""
+    options = [{'url': 'example.com', 'selector': 'test'}]
+    result = select_load_link_options(url='example.com', options=options)
+    assert result == {'selector': 'test'}
+
+    result = select_load_link_options(url='example.com/somepath', options=options)
+    assert result == {'selector': 'test'}
+
+    result = select_load_link_options(url='someurl.org', options=options)
+    assert result == {}

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -50,7 +50,8 @@ def test_document_has_changed():
     result = document_has_changed(doc1, collection.uuid, '1')
     assert result is True
 
-    add_document(document=Document(page_content='another'), collection_name='test', document_id='1')
+    add_document(document=Document(page_content='another'),
+                 collection_name='test', document_id='1')
     result = document_has_changed(doc1, collection.uuid, '1')
     assert result is True
 


### PR DESCRIPTION
This PR introduces a new `update_collection_links` command do the following:

* find documents for a collection having `type`:`files` and a populated `url` in metadata 
* check current `url` text content and compare it with the corresponding text stored 
* if the url text content has changed replaced the indexed content with the new one

A new ordering `part` metadata key (from 1 to N) has been introduced to be able to restore the original content in the correct order.
   