### PR TITLE
Add `document_id` query string to `/index/{{collection_id}}/documents_metadata` endpoint

### DIFF
--- a/brevia/index.py
+++ b/brevia/index.py
@@ -154,9 +154,12 @@ def update_metadata(
 def documents_metadata(
     collection_id: str,
     filter: dict[str, str] = {},
+    document_id: str = None,
 ):
     """ Read documents metadata of a collection"""
     query_filters = [EmbeddingStore.collection_id == collection_id]
+    if document_id:
+        query_filters.append(EmbeddingStore.custom_id == document_id)
     query_filters.extend(metadata_filters(filter=filter))
     with Session(connection.db_connection()) as session:
         query = session.query(EmbeddingStore.custom_id, EmbeddingStore.cmetadata)

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -210,6 +210,7 @@ def index_docs_metadata(collection_id: str, request: Request):
     return index.documents_metadata(
         collection_id=collection_id,
         filter=read_filter(request=request),
+        document_id=request.query_params.get('document_id'),
     )
 
 

--- a/tests/routers/test_index_router.py
+++ b/tests/routers/test_index_router.py
@@ -286,3 +286,12 @@ def test_get_index_documents_metadata():
         'cmetadata': {'type': 'questions'},
         'custom_id': '456'
     }]
+
+    query = 'document_id=123'
+    response = client.get(f'/index/{collection.uuid}/documents_metadata?{query}')
+    assert response.status_code == 200
+    data = response.json()
+    assert data == [{
+        'cmetadata': {'type': 'documents'},
+        'custom_id': '123'
+    }]


### PR DESCRIPTION
This PR adds a `document_id` query string to get metadata of a single document
