### PR TITLE
Migrate metadata column to JSONB

### DIFF
--- a/brevia/alembic/versions/95d93297832c_migration_to_jsonb_format.py
+++ b/brevia/alembic/versions/95d93297832c_migration_to_jsonb_format.py
@@ -1,0 +1,36 @@
+"""Migration to JSONB format
+
+Revision ID: 95d93297832c
+Revises: b34017752e45
+Create Date: 2024-05-10 18:25:42.596761
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, JSON
+
+# revision identifiers, used by Alembic.
+revision = '95d93297832c'
+down_revision = 'b34017752e45'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        'langchain_pg_embedding',
+        'cmetadata',
+        existing_type=sa.TEXT,
+        type_=JSONB,
+        postgresql_using='cmetadata::jsonb'
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        'langchain_pg_embedding',
+        'cmetadata',
+        existing_type=sa.TEXT,
+        type_=JSON,
+        postgresql_using='cmetadata::json'
+    )

--- a/brevia/index.py
+++ b/brevia/index.py
@@ -73,6 +73,7 @@ def add_document(
         collection_name=collection_name,
         connection_string=connection.connection_string(),
         ids=[document_id] * len(texts),
+        use_jsonb=True,
     )
 
     return len(texts)

--- a/brevia/query.py
+++ b/brevia/query.py
@@ -109,6 +109,7 @@ def search_vector_qa(
         embedding_function=load_embeddings(),
         collection_name=search.collection,
         distance_strategy=strategy,
+        use_jsonb=True,
     )
 
     return docsearch.similarity_search_with_score(
@@ -172,6 +173,7 @@ def conversation_chain(
         embedding_function=load_embeddings(),
         collection_name=collection.name,
         distance_strategy=strategy,
+        use_jsonb=True,
     )
 
     prompts = collection.cmetadata.get('prompts')

--- a/brevia/query.py
+++ b/brevia/query.py
@@ -90,7 +90,7 @@ class SearchQuery(BaseModel):
     collection: str
     docs_num: int | None = None
     distance_strategy_name: str = 'cosine',
-    filter: dict[str, str | dict] | None = None
+    filter: dict[str, str | dict | list] | None = None
 
 
 def search_vector_qa(

--- a/tests/routers/test_qa_router.py
+++ b/tests/routers/test_qa_router.py
@@ -40,7 +40,7 @@ def test_chat_filter():
     body = {
         'question': 'How?',
         'collection': 'test_collection',
-        'filter': {'category': {'in': ['first', 'third']}},
+        'filter': {'category': {'$in': ['first', 'third']}},
     }
     response = client.post(
         '/chat',

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -82,32 +82,40 @@ def test_search_vector_filter():
     result = search_vector_qa(search=SearchQuery(
         query='test',
         collection='test',
-        filter={'category': {'in': ['first', 'second']}},
+        filter={'category': {'$in': ['first', 'second']}},
     ))
     assert len(result) == 2
     result = search_vector_qa(search=SearchQuery(
         query='test',
         collection='test',
-        filter={'category': {'gt': 'first'}},
+        filter={'category': {'$gt': 'first'}},
     ))
     assert len(result) == 1
     result = search_vector_qa(search=SearchQuery(
         query='test',
         collection='test',
-        filter={'category': {'lt': 'first'}},
+        filter={'category': {'$lt': 'first'}},
     ))
     assert len(result) == 0
-    # 'GE' and 'LE' operators not yet supported
-    # result = search_vector_qa(search=SearchQuery(
-    #     query='test',
-    #     collection='test',
-    #     filter={'category': {'ge': 'aaaaa', 'le': 'zzzzz'}},
-    # ))
-    # assert len(result) == 2
     result = search_vector_qa(search=SearchQuery(
         query='test',
         collection='test',
-        filter={'category': {'ne': 'first'}},
+        filter={'$and': [
+            {'category': {'$gte': 'aaaaa'}},
+            {'category': {'$lte': 'zzzzz'}},
+        ]},
+    ))
+    assert len(result) == 2
+    result = search_vector_qa(search=SearchQuery(
+        query='test',
+        collection='test',
+        filter={'category': {'$lte': 'zzzzz'}},
+    ))
+    assert len(result) == 2
+    result = search_vector_qa(search=SearchQuery(
+        query='test',
+        collection='test',
+        filter={'category': {'$ne': 'first'}},
     ))
     assert len(result) == 1
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -109,12 +109,6 @@ def test_search_vector_filter():
     result = search_vector_qa(search=SearchQuery(
         query='test',
         collection='test',
-        filter={'category': {'$lte': 'zzzzz'}},
-    ))
-    assert len(result) == 2
-    result = search_vector_qa(search=SearchQuery(
-        query='test',
-        collection='test',
         filter={'category': {'$ne': 'first'}},
     ))
     assert len(result) == 1


### PR DESCRIPTION
Use the more efficient and fast `JSONB` type for `cmetadata` column in embeddings table, instead of `JSON` 