### PR TITLE
Callback when loading web links

### DIFF
--- a/brevia/load_file.py
+++ b/brevia/load_file.py
@@ -111,10 +111,10 @@ def read_html_url(
     temp_file = tempfile.NamedTemporaryFile(delete=False)
     response = requests.get(url)
     response.raise_for_status()
-    selector = loader_kwargs.pop('selector', '')
-    callback = loader_kwargs.pop('callback', '')
     with open(temp_file.name, 'w') as file:  # pylint: disable=missing-timeout
-        file.write(filter_html(html=response.text, selector=selector, callback=callback))
+        file.write(filter_html(html=response.text,
+                               selector=loader_kwargs.pop('selector', ''),
+                               callback=loader_kwargs.pop('callback', '')))
     loader = BSHTMLLoader(file_path=temp_file.name, **loader_kwargs)
     docs = loader.load()
     os.unlink(temp_file.name)


### PR DESCRIPTION
This PR adds an optional callback that can be used when loading a web page link in a collection.

 Example

```http

POST /index/link
{
  "link": "https://www.example.com",
  "collection_id": "{uuid}",
  "document_id": "123",
  "metadata": {"type": "links"},
  "options": {"callback": "my_module.my_function"}
}
```

`my_module.my_function` will be imported and called upon the HTML content before saving the extracted text in the `{uuid}` collection.
