### PR TITLE
Fix `import_file` command and collection metadata in indexing

### DIFF
--- a/brevia/index.py
+++ b/brevia/index.py
@@ -70,11 +70,11 @@ def add_document(
 ) -> int:
     """ Add document to index and return number of splitted text chunks"""
     collection = single_collection_by_name(collection_name)
-    collection_meta = collection.cmetadata if collection and collection.cmetadata else {}
-    embed_conf = collection_meta.get('embeddings', None)
+    coll_meta = collection.cmetadata if collection and collection.cmetadata else {}
+    embed_conf = coll_meta.get('embeddings', None)
     texts = split_document(
         document=document,
-        collection_meta=collection_meta,
+        collection_meta=coll_meta,
     )
     PGVector.from_documents(
         embedding=load_embeddings(embed_conf),
@@ -108,8 +108,10 @@ def create_splitter(collection_meta: dict) -> TextSplitter:
         'text_splitter',
         settings.text_splitter.copy()
     )
-    chunk_size = collection_meta.get('chunk_size', settings.text_chunk_size)
-    chunk_overlap = collection_meta.get('chunk_overlap', settings.text_chunk_overlap)
+    chunk_size = int(collection_meta.get('chunk_size', settings.text_chunk_size))
+    chunk_overlap = int(
+        collection_meta.get('chunk_overlap', settings.text_chunk_overlap)
+    )
 
     if not custom_splitter:
         return NLTKTextSplitter(

--- a/brevia/index.py
+++ b/brevia/index.py
@@ -70,10 +70,11 @@ def add_document(
 ) -> int:
     """ Add document to index and return number of splitted text chunks"""
     collection = single_collection_by_name(collection_name)
-    embed_conf = collection.cmetadata.get('embeddings', None) if collection else None
+    collection_meta = collection.cmetadata if collection and collection.cmetadata else {}
+    embed_conf = collection_meta.get('embeddings', None)
     texts = split_document(
         document=document,
-        collection_meta=collection.cmetadata if collection else {},
+        collection_meta=collection_meta,
     )
     PGVector.from_documents(
         embedding=load_embeddings(embed_conf),

--- a/brevia/load_file.py
+++ b/brevia/load_file.py
@@ -5,6 +5,8 @@ from importlib import import_module
 import mimetypes
 import tempfile
 from typing import List, Any
+from urllib.parse import urlparse
+from pathlib import Path
 import requests
 from bs4 import BeautifulSoup
 from langchain_community.document_loaders.html_bs import BSHTMLLoader
@@ -80,25 +82,35 @@ def read_txt_file(
     return cleanup_text(text).strip()
 
 
+def read_csv_file(
+    file_path: str,
+) -> str:
+    """
+    Load CSV file and return its content
+    """
+    docs = load_documents_csv(file_path=file_path)
+
+    return ' '.join([cleanup_text(item.page_content) for item in docs]).strip()
+
+
 def read(
     file_path: str,
     **loader_kwargs: Any,
 ) -> str:
     """
-    Load text from a txt o pdf file (for now, more formats to come)
+    Load text from a file, see `MIME_TYPES_READERS` for supported content types
     """
 
     if not os.path.isfile(file_path):
         raise FileNotFoundError(file_path)
 
     mtype = mimetypes.guess_type(file_path)[0]
-    if mtype not in ['application/pdf', 'text/plain']:
+    if mtype not in MIME_TYPES_LOADERS:
         raise ValueError(f'Unsupported file content type "{mtype}"')
 
-    if mtype == 'application/pdf':
-        return read_pdf_file(file_path=file_path, **loader_kwargs)
+    read_function = MIME_TYPES_READERS[mtype]
 
-    return read_txt_file(file_path=file_path)
+    return read_function(file_path, **loader_kwargs)
 
 
 def read_html_url(
@@ -108,13 +120,21 @@ def read_html_url(
     """
     Load text from HTML content of web page URL
     """
+    parsed_url = urlparse(url)
+    remote = True if parsed_url.scheme not in ['file', ''] else False
     temp_file = tempfile.NamedTemporaryFile(delete=False)
-    response = requests.get(url)
-    response.raise_for_status()
+    if remote:
+        response = requests.get(url)
+        response.raise_for_status()
+        text = response.text
+    else:
+        text = Path(url).read_text()
+
     with open(temp_file.name, 'w') as file:  # pylint: disable=missing-timeout
-        file.write(filter_html(html=response.text,
-                               selector=loader_kwargs.pop('selector', ''),
-                               callback=loader_kwargs.pop('callback', '')))
+        content = filter_html(
+            html=text, selector=loader_kwargs.pop('selector', ''),
+            callback=loader_kwargs.pop('callback', ''))
+        file.write(content)
     loader = BSHTMLLoader(file_path=temp_file.name, **loader_kwargs)
     docs = loader.load()
     os.unlink(temp_file.name)
@@ -180,4 +200,11 @@ MIME_TYPES_LOADERS = {
     'text/plain': load_documents_txt,
     'text/csv': load_documents_csv,
     'text/html': load_documents_html,
+}
+
+MIME_TYPES_READERS = {
+    'application/pdf': read_pdf_file,
+    'text/plain': read_txt_file,
+    'text/csv': read_csv_file,
+    'text/html': read_html_url,
 }

--- a/brevia/utilities/files_import.py
+++ b/brevia/utilities/files_import.py
@@ -3,7 +3,7 @@ import os
 from typing import List, Any
 from langchain_core.documents import Document
 from brevia.index import add_document
-from brevia.load_file import load_documents
+from brevia.load_file import read
 
 
 def index_file_folder(
@@ -31,7 +31,15 @@ def load_file_folder_documents(file_path: str, **kwargs: Any) -> List[Document]:
     if os.path.isdir(file_path):
         docs = []
         for file in os.listdir(file_path):
-            docs += load_documents(file_path=f'{file_path}/{file}', **kwargs)
+            docs += Document(
+                page_content=read(file_path=f'{file_path}/{file}', **kwargs),
+                metadata={'type': 'files', 'path': file_path},
+            )
         return docs
 
-    return load_documents(file_path=file_path, **kwargs)
+    doc = Document(
+        page_content=read(file_path=file_path, **kwargs),
+        metadata={'type': 'files', 'path': file_path},
+    )
+
+    return [doc]

--- a/brevia/utilities/files_import.py
+++ b/brevia/utilities/files_import.py
@@ -31,10 +31,10 @@ def load_file_folder_documents(file_path: str, **kwargs: Any) -> List[Document]:
     if os.path.isdir(file_path):
         docs = []
         for file in os.listdir(file_path):
-            docs += Document(
+            docs.append(Document(
                 page_content=read(file_path=f'{file_path}/{file}', **kwargs),
                 metadata={'type': 'files', 'path': file_path},
-            )
+            ))
         return docs
 
     doc = Document(

--- a/tests/test_load_file.py
+++ b/tests/test_load_file.py
@@ -61,9 +61,17 @@ def test_load_documents():
     assert len(docs) == 1
 
 
+def test_read_fail():
+    """Test read failure"""
+    file_path = f'{Path(__file__).parent}/files/silence.mp3'
+    with pytest.raises(ValueError) as exc:
+        read(file_path=file_path)
+    assert str(exc.value) == 'Unsupported file content type "audio/mpeg"'
+
+
 def test_load_documents_fail():
     """Test load_documents failure"""
     file_path = f'{Path(__file__).parent}/files/silence.mp3'
     with pytest.raises(ValueError) as exc:
-        read(file_path=file_path)
+        load_documents(file_path=file_path)
     assert str(exc.value) == 'Unsupported file content type "audio/mpeg"'


### PR DESCRIPTION
in this PR:

* same documents splitting logic is used in `import_file` command as in `POST /index/*` endpoints 
* collection metadata are now handled correctly:
   - `collection.cmetadata` may be `NULL` 
   - `chunk_size/overlap` params are now converted to `int` 
   