### PR TITLE
Introduce `refine` text analysis task and service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ brevia/extensions/*
 !brevia/extensions/__init__.py
 
 # local prompts folder
-prompts/
+./prompts/
 
 # Editor directories and files
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ coverage.xml
 brevia/extensions/*
 !brevia/extensions/__init__.py
 
+# local prompts folder
+prompts/
+
 # Editor directories and files
 .idea
 .DS_Store

--- a/brevia/prompts/text_analysis/questions_initial.yml
+++ b/brevia/prompts/text_analysis/questions_initial.yml
@@ -1,0 +1,12 @@
+# Reference initial prompt to generate questions from a given text.
+_type: prompt
+input_variables:
+    ["text"]
+template: |
+    Analyze the following text and generate 1-2 multiple choice questions, each with four options
+    (A, B, C, D), of which only one is correct.
+    Highlight the correct answer and make sure that the questions are relevant and understandable.
+
+    Reference text:
+    -------------------
+    {text}

--- a/brevia/prompts/text_analysis/questions_refine.yml
+++ b/brevia/prompts/text_analysis/questions_refine.yml
@@ -1,0 +1,14 @@
+# Reference refine prompt to generate questions from a given text.
+_type: prompt
+input_variables:
+    ["existing_answer", "text"]
+template: |
+    You are given the following partial document containing a list of multiple choice questions:
+    Partial Document:
+    -------------------
+    {existing_answer}
+    -------------------
+    Rewrite the list of questions by adding 1-2 more questions at the bottom from the context provided below:
+    -------------
+    {text}
+    -------------------

--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -156,7 +156,7 @@ class Settings(BaseSettings):
                 db_conf = read_db_conf(engine.connect())
                 self.update(db_conf)
             engine.dispose()
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-excepttion-caught
             logging.getLogger(__name__).error('Failed to read config from db: %s', exc)
 
     def setup_defaults(self):

--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -2,7 +2,7 @@
 import logging
 from functools import lru_cache
 from typing import Annotated, Any
-from os import environ
+from os import environ, getcwd
 from urllib import parse
 from sqlalchemy import NullPool, create_engine, Column, String, func, inspect
 from sqlalchemy.engine import Connection
@@ -106,6 +106,9 @@ class Settings(BaseSettings):
     summ_default_chain: str = 'stuff'
     summ_token_splitter: int = 4000
     summ_token_overlap: int = 500
+
+    # Prompt files base path - local file system or remote URL
+    prompts_base_path: str = Field(default=f'{getcwd()}/prompts', exclude=True)
 
     # App metadata
     block_openapi_urls: bool = False

--- a/brevia/tasks/base.py
+++ b/brevia/tasks/base.py
@@ -1,0 +1,22 @@
+"""Base class for analysis tasks"""
+from abc import ABC, abstractmethod
+from typing import Any
+from brevia.settings import get_settings
+
+
+class BaseAnalysisTask(ABC):
+    """Base class for analysis tasks"""
+    prompts: dict[str, Any] = {}
+
+    @abstractmethod
+    def perform_task(self) -> dict:
+        """Perform task logic using payload"""
+
+    @abstractmethod
+    def load_analysis_prompts(self, prompts: dict | None = None):
+        """Load analysis prompts usign optional input prompts"""
+
+    @classmethod
+    def prompt_path(cls, file_name: str) -> str:
+        """Prompt path"""
+        return f'{get_settings().prompts_base_path}/{file_name}'

--- a/brevia/tasks/text_analysis.py
+++ b/brevia/tasks/text_analysis.py
@@ -1,0 +1,111 @@
+"""Base class for text analysis services"""
+from langchain.docstore.document import Document
+from langchain_core.callbacks import Callbacks
+from langchain.chains.combine_documents.refine import RefineDocumentsChain
+from langchain.chains.llm import LLMChain
+from langchain_core.language_models import BaseLanguageModel
+from langchain_core.prompts.loading import load_prompt, load_prompt_from_config
+from brevia.callback import LoggingCallbackHandler
+from brevia.load_file import read
+from brevia.index import split_document
+from brevia.models import load_chatmodel
+from brevia.settings import get_settings
+from brevia.tasks.base import BaseAnalysisTask
+
+
+class BaseTextAnalysisTask(BaseAnalysisTask):
+    """Base class for text analysis tasks"""
+
+    def text_documents(
+            self,
+            file_path: str,
+            options: dict | None = None
+    ) -> list[Document]:
+        """Load text from file and split into documents"""
+        text = read(file_path=file_path)
+        options = options or {}
+
+        return split_document(Document(page_content=text), collection_meta=options)
+
+
+class RefineTextAnalysisTask(BaseTextAnalysisTask):
+    """Text analysis using refine chain"""
+    def __init__(
+        self,
+        file_path: str,
+        prompts: dict | None = None,
+        llm_conf: dict | None = None,
+        text_options: dict | None = None,
+    ):
+        self.file_path = file_path
+        self.llm_conf = llm_conf
+        self.text_options = text_options
+        self.load_analysis_prompts(prompts)
+
+    def perform_task(self):
+        """Service logic"""
+        text_documents = self.text_documents(
+                self.file_path, options=self.text_options)
+
+        result = self.run_refine_chain(text_documents)
+
+        return {
+            'input_documents': [{
+                'page_content': doc.page_content,
+                'metadata': doc.metadata
+            } for doc in text_documents
+            ],
+            'output_text': result.get('output_text')
+        }
+
+    def load_analysis_prompts(self, prompts: dict | None = None):
+        """Load analysis prompts"""
+        if not prompts or 'initial_prompt' not in prompts or 'refine_prompt' not in prompts:
+            raise ValueError(
+                "Both 'initial_prompt' and 'refine_prompt' must be provided.")
+
+        for key, value in prompts.items():
+            if isinstance(value, dict):
+                prompts[key] = load_prompt_from_config(value)
+            else:
+                prompts[key] = load_prompt(self.prompt_path(value))
+
+        self.prompts = prompts
+
+    def run_refine_chain(
+        self,
+        pages: list[Document],
+    ) -> dict[str, str]:
+        """Run analysis with refine chain"""
+        logging_handler = LoggingCallbackHandler()
+        llm_conf = self.llm_conf or get_settings().summarize_llm.copy()
+        llm_conf['callbacks'] = [logging_handler]
+        llm_text = load_chatmodel(llm_conf)
+
+        # Using refine algorithm with modified prompts
+        # for informations extraction on multiple pages
+        chain = self.load_refine_chain(
+            llm=llm_text,
+            callbacks=[logging_handler],
+        )
+
+        return chain.invoke({'input_documents': pages}, return_only_outputs=True)
+
+    def load_refine_chain(
+        self,
+        llm: BaseLanguageModel,
+        callbacks: Callbacks,
+        verbose: bool = True,
+    ) -> RefineDocumentsChain:
+        """Load refine chain"""
+        initial_prompt = self.prompts.get('initial_prompt')
+        refine_prompt = self.prompts.get('refine_prompt')
+
+        return RefineDocumentsChain(
+            initial_llm_chain=LLMChain(llm=llm, prompt=initial_prompt, verbose=verbose),
+            refine_llm_chain=LLMChain(llm=llm, prompt=refine_prompt, verbose=verbose),
+            document_variable_name='text',
+            initial_response_name='existing_answer',
+            verbose=verbose,
+            callbacks=callbacks,
+        )

--- a/brevia/tasks/text_analysis.py
+++ b/brevia/tasks/text_analysis.py
@@ -60,9 +60,11 @@ class RefineTextAnalysisTask(BaseTextAnalysisTask):
 
     def load_analysis_prompts(self, prompts: dict | None = None):
         """Load analysis prompts"""
-        if not prompts or 'initial_prompt' not in prompts or 'refine_prompt' not in prompts:
-            raise ValueError(
-                "Both 'initial_prompt' and 'refine_prompt' must be provided.")
+        if not prompts:
+            raise ValueError('Prompts dictionary must be provided.')
+        missing = {'initial_prompt', 'refine_prompt'} - prompts.keys()
+        if missing:
+            raise ValueError(f'Missing required prompts: {", ".join(missing)}')
 
         for key, value in prompts.items():
             if isinstance(value, dict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def update_settings():
     settings.update(test_settings)
     settings.setup_environment()
     # Force tokens and test models vars
+    settings.prompts_base_path = f'{Path(__file__).parent}/files/prompts'
     settings.tokens_secret = ''
     settings.tokens_users = ''
     settings.status_token = ''

--- a/tests/files/prompts/initial_prompt.yml
+++ b/tests/files/prompts/initial_prompt.yml
@@ -1,0 +1,12 @@
+_type: prompt
+input_variables:
+    ["text"]
+template: |
+    Analizza il seguente testo che contiene informazioni normative e giuridiche rilevanti per la pubblica amministrazione.
+    Sulla base di questo contesto, genera 1-2 domande a risposta multipla, ciascuna con quattro opzioni (A, B, C, D),
+    di cui una sola risposta corretta.
+    Evidenzia la risposta corretta e assicurati che le domande siano pertinenti e comprensibili.
+
+    Testo di riferimento:
+    -------------
+    {text}

--- a/tests/files/prompts/initial_prompt.yml
+++ b/tests/files/prompts/initial_prompt.yml
@@ -2,11 +2,10 @@ _type: prompt
 input_variables:
     ["text"]
 template: |
-    Analizza il seguente testo che contiene informazioni normative e giuridiche rilevanti per la pubblica amministrazione.
-    Sulla base di questo contesto, genera 1-2 domande a risposta multipla, ciascuna con quattro opzioni (A, B, C, D),
-    di cui una sola risposta corretta.
-    Evidenzia la risposta corretta e assicurati che le domande siano pertinenti e comprensibili.
+    Analyze the following text and generate 1-2 multiple choice questions, each with four options
+    (A, B, C, D), of which only one is correct.
+    Highlight the correct answer and make sure that the questions are relevant and understandable.
 
-    Testo di riferimento:
-    -------------
+    Reference text:
+    -------------------
     {text}

--- a/tests/files/prompts/refine_prompt.yml
+++ b/tests/files/prompts/refine_prompt.yml
@@ -2,16 +2,12 @@ _type: prompt
 input_variables:
     ["existing_answer", "text"]
 template: |
-    Ti viene fornito il seguente documento parziale contenente una lista di domande a risposta multipla:
-
-    Documento parziale:
+    You are given the following partial document containing a list of multiple choice questions:
+    Partial Document:
     -------------------
     {existing_answer}
     -------------------
-
-    Riscrivi la lista di domande aggiungendo in fondo altre 1-2 domande ricavate dal contesto fornito di seguito:
-
-    --------------
+    Rewrite the list of questions by adding 1-2 more questions at the bottom from the context provided below:
+    -------------
     {text}
-    --------------
-
+    -------------------

--- a/tests/files/prompts/refine_prompt.yml
+++ b/tests/files/prompts/refine_prompt.yml
@@ -1,0 +1,17 @@
+_type: prompt
+input_variables:
+    ["existing_answer", "text"]
+template: |
+    Ti viene fornito il seguente documento parziale contenente una lista di domande a risposta multipla:
+
+    Documento parziale:
+    -------------------
+    {existing_answer}
+    -------------------
+
+    Riscrivi la lista di domande aggiungendo in fondo altre 1-2 domande ricavate dal contesto fornito di seguito:
+
+    --------------
+    {text}
+    --------------
+

--- a/tests/tasks/test_text_analysys.py
+++ b/tests/tasks/test_text_analysys.py
@@ -4,10 +4,12 @@ import pytest
 from brevia.tasks.text_analysis import RefineTextAnalysisTask
 import yaml
 
+FILES_PATH = f'{Path(__file__).parent.parent}/files'
+
 
 def test_refine_text_analysis():
     """Test refine text analysis task"""
-    file_path = f'{Path(__file__).parent.parent}/files/docs/test.txt'
+    file_path = f'{FILES_PATH}/docs/test.txt'
     prompts = {
         'initial_prompt': 'initial_prompt.yml',
         'refine_prompt': 'refine_prompt.yml'
@@ -16,9 +18,9 @@ def test_refine_text_analysis():
     result = task.perform_task()
     assert 'input_documents' in result
     assert 'output_text' in result
-    with open(f'{Path(__file__).parent.parent}/files/prompts/initial_prompt.yml', 'r') as file:
+    with open(f'{FILES_PATH}/prompts/initial_prompt.yml', 'r') as file:
         initial_prompt_dict = yaml.safe_load(file)
-    with open(f'{Path(__file__).parent.parent}/files/prompts/refine_prompt.yml', 'r') as file:
+    with open(f'{FILES_PATH}/prompts/refine_prompt.yml', 'r') as file:
         refine_prompt_dict = yaml.safe_load(file)
     assert isinstance(initial_prompt_dict, dict)
     prompts = {
@@ -33,16 +35,20 @@ def test_refine_text_analysis():
 
 def test_refine_text_analysis_fail():
     """Test refine text analysis task failure"""
-    file_path = f'{Path(__file__).parent.parent}/files/docs/test.txt'
+    file_path = f'{FILES_PATH}/docs/test.txt'
     with pytest.raises(ValueError) as exc:
         RefineTextAnalysisTask(file_path=file_path)
-    assert str(exc.value) == "Both 'initial_prompt' and 'refine_prompt' must be provided."
+    assert str(exc.value) == "Prompts dictionary must be provided."
+
+    with pytest.raises(ValueError) as exc:
+        RefineTextAnalysisTask(file_path=file_path, prompts={'initial_prompt': 'init'})
+    assert str(exc.value) == "Missing required prompts: refine_prompt"
 
     prompts = {
         'initial_prompt': 'initial_prompt.yml',
         'refine_prompt': 'refine_prompt.yml'
     }
-    file_path = f'{Path(__file__).parent.parent}/files/docs/not.found'
+    file_path = f'{FILES_PATH}/docs/not.found'
     with pytest.raises(FileNotFoundError) as exc:
         an = RefineTextAnalysisTask(file_path=file_path, prompts=prompts)
         an.perform_task()

--- a/tests/tasks/test_text_analysys.py
+++ b/tests/tasks/test_text_analysys.py
@@ -1,0 +1,48 @@
+"""Test text analysis tasks"""
+from pathlib import Path
+import pytest
+from brevia.tasks.text_analysis import RefineTextAnalysisTask
+import yaml
+
+
+def test_refine_text_analysis():
+    """Test refine text analysis task"""
+    file_path = f'{Path(__file__).parent.parent}/files/docs/test.txt'
+    prompts = {
+        'initial_prompt': 'initial_prompt.yml',
+        'refine_prompt': 'refine_prompt.yml'
+    }
+    task = RefineTextAnalysisTask(file_path=file_path, prompts=prompts)
+    result = task.perform_task()
+    assert 'input_documents' in result
+    assert 'output_text' in result
+    with open(f'{Path(__file__).parent.parent}/files/prompts/initial_prompt.yml', 'r') as file:
+        initial_prompt_dict = yaml.safe_load(file)
+    with open(f'{Path(__file__).parent.parent}/files/prompts/refine_prompt.yml', 'r') as file:
+        refine_prompt_dict = yaml.safe_load(file)
+    assert isinstance(initial_prompt_dict, dict)
+    prompts = {
+        'initial_prompt': initial_prompt_dict,
+        'refine_prompt': refine_prompt_dict
+    }
+    task = RefineTextAnalysisTask(file_path=file_path, prompts=prompts)
+    result = task.perform_task()
+    assert 'input_documents' in result
+    assert 'output_text' in result
+
+
+def test_refine_text_analysis_fail():
+    """Test refine text analysis task failure"""
+    file_path = f'{Path(__file__).parent.parent}/files/docs/test.txt'
+    with pytest.raises(ValueError) as exc:
+        RefineTextAnalysisTask(file_path=file_path)
+    assert str(exc.value) == "Both 'initial_prompt' and 'refine_prompt' must be provided."
+
+    prompts = {
+        'initial_prompt': 'initial_prompt.yml',
+        'refine_prompt': 'refine_prompt.yml'
+    }
+    file_path = f'{Path(__file__).parent.parent}/files/docs/not.found'
+    with pytest.raises(FileNotFoundError) as exc:
+        an = RefineTextAnalysisTask(file_path=file_path, prompts=prompts)
+        an.perform_task()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -41,3 +41,18 @@ def test_refine_text_analysis():
     result = service.run(payload)
     assert 'output' in result
     assert 'token_data' in result
+
+
+def test_refine_text_analysis_fail():
+    """Test refine text analysis service failure"""
+    service = RefineTextAnalysisService()
+    with pytest.raises(ValueError) as exc:
+        service.run({})
+    assert str(exc.value) == 'Invalid service payload - {}'
+
+    with pytest.raises(ValueError) as exc:
+        service.run({
+            'file_path': '/some/path',
+            'prompts': {'a': 'b'}
+        })
+    assert str(exc.value).startswith('Invalid service payload - ')

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,7 +1,11 @@
 """Services module tests"""
 from pathlib import Path
 import pytest
-from brevia.services import SummarizeFileService, SummarizeTextService
+from brevia.services import (
+    SummarizeFileService,
+    SummarizeTextService,
+    RefineTextAnalysisService,
+)
 
 
 def test_summarize_failures():
@@ -22,3 +26,18 @@ def test_summarize_failures():
     with pytest.raises(ValueError) as exc:
         service.run({'file_path': file_path})
     assert str(exc.value) == 'Empty text'
+
+
+def test_refine_text_analysis():
+    """Test refine text analysis service"""
+    payload = {
+        'file_path': f'{Path(__file__).parent}/files/docs/test.txt',
+        'prompts': {
+            'initial_prompt': 'initial_prompt.yml',
+            'refine_prompt': 'refine_prompt.yml'
+        }
+    }
+    service = RefineTextAnalysisService()
+    result = service.run(payload)
+    assert 'output' in result
+    assert 'token_data' in result


### PR DESCRIPTION
In this PR:

* a new `RefineTextAnalysisTask` and its abstract parent `BaseAnalysisTask` have been introduced to perform simple tasks with custom provided prompts using a `refine` algorithm provided by LangChain `RefineDocumentsChain` (that will be migrated to new LCEL format soon)
* a new `RefineTextAnalysisService` has also been added to implement this task in an async job.
* a new `prompts_base_path` setting  has been added with `./prompts` as default, relative to the current working dir, to define a base file path or URL to store and load prompts by name  