### PR TITLE
Handle any option in `link_load_options` metadata setting

### DIFF
--- a/brevia/index.py
+++ b/brevia/index.py
@@ -309,14 +309,25 @@ def document_has_changed(document: Document, collection_id: str, document_id: st
     return False
 
 
-def select_load_link_options(url: str, options: list):
+def select_load_link_options(url: str, options: list) -> dict:
     """ Select load link options for a given URL"""
+    unique_keys = set()
+    for option in options:
+        unique_keys.update(option.keys())
+    unique_keys.discard('url')
+
+    res = {}
+    for key in unique_keys:
+        res[key] = load_link_option(url=url, name=key, options=options)
+
+    return res
+
+
+def load_link_option(url: str, name: str, options: list) -> str | None:
+    """Find load link option for a given URL"""
     item = next((x for x in options if url == x['url']), None)
-    if item:
-        return {'selector': item.get('selector', '')}
+    if item and item.get(name) is not None:
+        return item.get(name)
 
     item = next((x for x in options if url.startswith(x['url'])), None)
-    if item:
-        return {'selector': item.get('selector', '')}
-
-    return {}
+    return item.get(name) if item else None

--- a/brevia/routers/index_router.py
+++ b/brevia/routers/index_router.py
@@ -133,6 +133,9 @@ def parse_link_and_index(item: IndexLink):
         collection.name,
         item.document_id
     )
+    if not item.options:
+        options = collection.cmetadata.get('link_load_options', [])
+        item.options = index.select_load_link_options(url=item.link, options=options)
 
     text = load_file.read_html_url(url=item.link, **item.options)
     if not text:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -100,15 +100,19 @@ def test_update_links_documents_http_error(mock_get):
 
 def test_select_load_link_options():
     """Test select_load_link_options method"""
-    options = [{'url': 'example.com', 'selector': 'test'}]
-    result = select_load_link_options(url='example.com', options=options)
-    assert result == {'selector': 'test'}
+    options = [
+        {'url': 'example.com', 'selector': 'test'},
+        {'url': 'example.com/some', 'selector': 'test2'},
+        {'url': 'example.com/other', 'other': 'value'}
+    ]
+    result = select_load_link_options(url='example.com/other', options=options)
+    assert result == {'selector': 'test', 'other': 'value'}
 
-    result = select_load_link_options(url='example.com/somepath', options=options)
-    assert result == {'selector': 'test'}
+    result = select_load_link_options(url='example.com/some', options=options)
+    assert result == {'selector': 'test2', 'other': None}
 
     result = select_load_link_options(url='someurl.org', options=options)
-    assert result == {}
+    assert result == {'selector': None, 'other': None}
 
 
 def test_custom_split():


### PR DESCRIPTION
This PR will enable any option to be used in `link_load_options` configuration. 
This options will be used in `POST /index/link` if no option are set in the request body, by looking at collection metadata.

As of today only `selector` option was selected. 
Internally `selector` and `callback` are used, but this change allows the introduction of other options in the future.
