### PR TITLE
Set alembic `script_location` config at runtime

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,8 +1,8 @@
 # A generic, single database configuration.
 
 [alembic]
-# path to migration scripts
-script_location = brevia/alembic
+# path to migration scripts, will be set by brevia at runtime
+#script_location = brevia/alembic
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/brevia/alembic/__init__.py
+++ b/brevia/alembic/__init__.py
@@ -1,20 +1,20 @@
 """DB migrations commands """
 from os import getcwd
-
+from os.path import dirname
 from alembic.config import Config
 from alembic import command
 
-
-ALEMBIC_CFG = Config(f'{getcwd()}/alembic.ini')
+alembic_cfg = Config(f'{getcwd()}/alembic.ini')
+alembic_cfg.set_main_option('script_location', dirname(__file__))
 
 
 def current(verbose=False):
-    command.current(ALEMBIC_CFG, verbose=verbose)
+    command.current(alembic_cfg, verbose=verbose)
 
 
 def upgrade(revision="head"):
-    command.upgrade(ALEMBIC_CFG, revision)
+    command.upgrade(alembic_cfg, revision)
 
 
 def downgrade(revision):
-    command.downgrade(ALEMBIC_CFG, revision)
+    command.downgrade(alembic_cfg, revision)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from alembic.config import Config
 from dotenv import dotenv_values
 from brevia.settings import Settings, get_settings
 from brevia.index import init_splitting_data
+import brevia.alembic
 
 
 def pytest_sessionstart(session):
@@ -45,6 +46,8 @@ def env_vars_db():
     update_settings()
     root_path = Path(__file__).parent.parent
     alembic_conf = Config(f'{root_path}/alembic.ini')
+    script_location = os.path.dirname(brevia.alembic.__file__)
+    alembic_conf.set_main_option('script_location', script_location)
     command.upgrade(alembic_conf, 'head')
 
     yield


### PR DESCRIPTION
This PR fixes a problem with alembic `script_location` configuration when using migrations commands using `brevia` package

`script_location` points to the folder containing alembic scripts: using `alembic.ini` in a project using `brevia` you may not know the correct path in advance. This happens, for instance, if your Brevia project supports multiple Python versions.

From now on this path will be set at runtime.  