### PR TITLE
Update `brevia_env_secrets` usage + new `GET  /providers/{provider}` endpoint + new `providers_env_vars` setting

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -65,6 +65,10 @@
 # SUMM_TOKEN_OVERLAP=500
 # SUMM_DEFAULT_CHAIN=stuff
 
+### Providers
+# Uncomment to customize the list of known providers environment variables that could be used by external services (mainly LLM providers)
+# PROVIDERS_ENV_VARS = '{"openai": ["OPENAI_API_KEY","OPENAI_ORG_ID","OPENAI_API_BASE"], "anthropic": ["ANTHROPIC_API_KEY"], "cohere": ["COHERE_API_KEY"], "deepseek": ["DEEPSEEK_API_KEY"], "ollama": ["OLLAMA_HOST"]}'
+
 ### General
 # VERBOSE_MODE=True
 

--- a/brevia/postman/Brevia API.postman_collection.json
+++ b/brevia/postman/Brevia API.postman_collection.json
@@ -1806,6 +1806,50 @@
                     "response": []
                 },
                 {
+                    "name": "Read configuration with key filter",
+                    "request": {
+                        "auth": {
+                            "type": "bearer",
+                            "bearer": [
+                                {
+                                    "key": "token",
+                                    "value": "{{access_token}}",
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json",
+                                "type": "text",
+                                "disabled": true
+                            }
+                        ],
+                        "url": {
+                            "raw": "{{baseUrl}}/config?key=providers&key=brevia_env_secrets",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "config"
+                            ],
+                            "query": [
+                                {
+                                    "key": "key",
+                                    "value": "providers"
+                                },
+                                {
+                                    "key": "key",
+                                    "value": "brevia_env_secrets"
+                                }
+                            ]
+                        }
+                    },
+                    "response": []
+                },
+                {
                     "name": "Read configuration schema",
                     "request": {
                         "auth": {
@@ -1964,6 +2008,120 @@
             ]
         },
         {
+            "name": "Providers",
+            "item": [
+                {
+                    "name": "providers - List available providers and models",
+                    "request": {
+                        "auth": {
+                            "type": "bearer",
+                            "bearer": [
+                                {
+                                    "key": "token",
+                                    "value": "{{access_token}}",
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json",
+                                "type": "text",
+                                "disabled": true
+                            }
+                        ],
+                        "url": {
+                            "raw": "{{baseUrl}}/providers",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "providers"
+                            ]
+                        }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "providers - List available providers without models",
+                    "request": {
+                        "auth": {
+                            "type": "bearer",
+                            "bearer": [
+                                {
+                                    "key": "token",
+                                    "value": "{{access_token}}",
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json",
+                                "type": "text",
+                                "disabled": true
+                            }
+                        ],
+                        "url": {
+                            "raw": "{{baseUrl}}/providers?list_models=false",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "providers"
+                            ],
+                            "query": [
+                                {
+                                    "key": "list_models",
+                                    "value": "false"
+                                }
+                            ]
+                        }
+                    },
+                    "response": []
+                },
+                {
+                    "name": "providers/{{provider}} - List available models for a single provider",
+                    "request": {
+                        "auth": {
+                            "type": "bearer",
+                            "bearer": [
+                                {
+                                    "key": "token",
+                                    "value": "{{access_token}}",
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "method": "GET",
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json",
+                                "type": "text",
+                                "disabled": true
+                            }
+                        ],
+                        "url": {
+                            "raw": "{{baseUrl}}/providers/{{provider}}",
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "path": [
+                                "providers",
+                                "{{provider}}"
+                            ]
+                        }
+                    },
+                    "response": []
+                }
+            ]
+        },
+        {
             "name": "upload_analyze - Upload file and analyze using extension",
             "event": [
                 {
@@ -2108,40 +2266,6 @@
                     "path": [
                         "jobs",
                         "{{job_id}}"
-                    ]
-                }
-            },
-            "response": []
-        },
-        {
-            "name": "providers - List available providers and models",
-            "request": {
-                "auth": {
-                    "type": "bearer",
-                    "bearer": [
-                        {
-                            "key": "token",
-                            "value": "{{access_token}}",
-                            "type": "string"
-                        }
-                    ]
-                },
-                "method": "GET",
-                "header": [
-                    {
-                        "key": "Content-Type",
-                        "value": "application/json",
-                        "type": "text",
-                        "disabled": true
-                    }
-                ],
-                "url": {
-                    "raw": "{{baseUrl}}/providers",
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "path": [
-                        "providers"
                     ]
                 }
             },

--- a/brevia/providers.py
+++ b/brevia/providers.py
@@ -10,15 +10,26 @@ from brevia.connection import db_connection
 from brevia.settings import get_settings, update_db_conf
 
 
-def list_providers():
+def list_providers(list_models: bool = True) -> list:
     """ List available providers and models """
     providers = []
     for provider in PROVIDER_MODELS_MAP.keys():
-        models = PROVIDER_MODELS_MAP.get(provider)()
-        item = {'model_provider': provider, 'models': models}
+        item = {'model_provider': provider}
+        if list_models:
+            models = PROVIDER_MODELS_MAP.get(provider)()
+            item['models'] = models
         providers.append(item)
 
     return providers
+
+
+def single_provider(provider: str) -> dict | None:
+    """ List available models for a provider """
+    if provider not in PROVIDER_MODELS_MAP:
+        return None
+
+    models = PROVIDER_MODELS_MAP.get(provider)()
+    return {'model_provider': provider, 'models': models}
 
 
 def update_providers(force: bool = False):

--- a/brevia/providers.py
+++ b/brevia/providers.py
@@ -34,14 +34,16 @@ def single_provider(provider: str) -> dict | None:
 
 def update_providers(force: bool = False):
     """ Update providers list in settings from API and save providers to DB """
+    log = logging.getLogger(__name__)
     settings = get_settings()
     if settings.providers and not force:
         return
     try:
         providers = list_providers()
+        log.info('Adding "providers" to brevia configuration DB')
         update_db_conf(db_connection(), {'providers': json.dumps(providers)})
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logging.getLogger(__name__).error('Failed to update providers: %s', exc)
+        log.error('Failed to update providers: %s', exc)
 
 
 def load_openai_models() -> list | None:

--- a/brevia/routers/config_router.py
+++ b/brevia/routers/config_router.py
@@ -67,7 +67,10 @@ def save_config(config: dict[str, Any]):
             f'Invalid configuration: {exc}',
         )
 
-    return update_db_conf(db_connection(), config)
+    result = update_db_conf(db_connection(), config)
+    # make sure settings are reloaded
+    get_settings()
+    return result
 
 
 @router.api_route(
@@ -80,4 +83,7 @@ def reset_config(keys: list[str]):
     """POST /config/reset endpoint, reset to default a list of settings """
     check_keys(keys)
 
-    return reset_db_conf(db_connection(), keys)
+    result = reset_db_conf(db_connection(), keys)
+    # make sure settings are reloaded
+    get_settings()
+    return result

--- a/brevia/routers/config_router.py
+++ b/brevia/routers/config_router.py
@@ -1,6 +1,6 @@
 """API endpoints to Brevia configuration"""
-from typing import Any
-from fastapi import APIRouter, HTTPException, status
+from typing import Annotated, Any
+from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import ValidationError
 from brevia.settings import (
     Settings,
@@ -21,9 +21,13 @@ router = APIRouter()
     dependencies=get_dependencies(json_content_type=False),
     tags=['Config'],
 )
-def get_config():
+def get_config(key: Annotated[list[str] | None, Query()] = None):
     """ /config endpoint, read Brevia configuration """
-    return get_settings().model_dump()
+    config = get_settings().model_dump()
+    if key is not None:
+        check_keys(key)
+        return {k: config[k] for k in key}
+    return config
 
 
 @router.api_route(

--- a/brevia/routers/providers_router.py
+++ b/brevia/routers/providers_router.py
@@ -1,7 +1,7 @@
 """API endpoints definitions to show available providers and models"""
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
 from brevia.dependencies import get_dependencies
-from brevia.providers import list_providers
+from brevia.providers import list_providers, single_provider
 
 router = APIRouter()
 
@@ -12,6 +12,24 @@ router = APIRouter()
     dependencies=get_dependencies(json_content_type=False),
     tags=['Providers'],
 )
-def api_providers():
+def api_providers(list_models: bool = True):
     """ /providers endpoint, list available providers and models """
-    return list_providers()
+    return list_providers(list_models=list_models)
+
+
+@router.api_route(
+    '/providers/{provider}',
+    methods=['GET'],
+    dependencies=get_dependencies(json_content_type=False),
+    tags=['Providers'],
+)
+def provider_models(provider: str):
+    """ /providers/{provider} endpoint, list available models for a provider """
+    res = single_provider(provider=provider)
+    if not res:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            f"Providers '{provider}' not found",
+        )
+
+    return res

--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -148,10 +148,11 @@ class Settings(BaseSettings):
         for key, value in self.brevia_env_secrets.items():
             environ[key] = value
             log.info('"%s" env var set', key)
-        for key in self.known_env_vars:
-            if key in environ and key not in self.brevia_env_secrets.keys():
-                self.brevia_env_secrets[key] = environ[key]
-                log.info('"%s" added to env secrets', key)
+        for provider in self.known_env_vars:
+            for key in self.known_env_vars[provider]:
+                if key in environ and key not in self.brevia_env_secrets.keys():
+                    self.brevia_env_secrets[key] = environ[key]
+                    log.info('"%s" added to env secrets', key)
 
     def connection_string(self) -> str:
         """ Db connection string from Settings """

--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -112,9 +112,9 @@ class Settings(BaseSettings):
     # Providers: list of available providers and models
     providers: Json = '[]'
 
-    # List of known environment variables that could be used by
+    # List of known providers environment variables that could be used by
     # external services (mainly LLM providers)
-    known_env_vars: Json[dict[str, list[str]]] = """{
+    providers_env_vars: Json[dict[str, list[str]]] = """{
         "openai": ["OPENAI_API_KEY","OPENAI_ORG_ID","OPENAI_API_BASE"],
         "anthropic": ["ANTHROPIC_API_KEY"],
         "cohere": ["COHERE_API_KEY"],
@@ -148,8 +148,8 @@ class Settings(BaseSettings):
         for key, value in self.brevia_env_secrets.items():
             environ[key] = value
             log.info('"%s" env var set', key)
-        for provider in self.known_env_vars:
-            for key in self.known_env_vars[provider]:
+        for provider in self.providers_env_vars:
+            for key in self.providers_env_vars[provider]:
                 if key in environ and key not in self.brevia_env_secrets.keys():
                     self.brevia_env_secrets[key] = environ[key]
                     log.info('"%s" added to env secrets', key)

--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -112,6 +112,16 @@ class Settings(BaseSettings):
     # Providers: list of available providers and models
     providers: Json = '[]'
 
+    # List of known environment variables that could be used by
+    # external services (mainly LLM providers)
+    known_env_vars: Json[dict[str, list[str]]] = """{
+        "openai": ["OPENAI_API_KEY","OPENAI_ORG_ID","OPENAI_API_BASE"],
+        "anthropic": ["ANTHROPIC_API_KEY"],
+        "cohere": ["COHERE_API_KEY"],
+        "deepseek": ["DEEPSEEK_API_KEY"],
+        "ollama": ["OLLAMA_HOST"]
+    }"""
+
     # App metadata
     block_openapi_urls: bool = False
 
@@ -126,7 +136,11 @@ class Settings(BaseSettings):
             keys = other.keys()
             other = Settings(**other)
         for key in keys:
-            setattr(self, key, getattr(other, key))
+            newattr = getattr(other, key)
+            if key == 'brevia_env_secrets':
+                current_secrets = getattr(self, key)
+                newattr = {**current_secrets, **newattr}
+            setattr(self, key, newattr)
 
     def setup_environment(self):
         """Setup some useful environment variables from `brevia_env_secrets`"""
@@ -134,6 +148,10 @@ class Settings(BaseSettings):
         for key, value in self.brevia_env_secrets.items():
             environ[key] = value
             log.info('"%s" env var set', key)
+        for key in self.known_env_vars:
+            if key in environ and key not in self.brevia_env_secrets.keys():
+                self.brevia_env_secrets[key] = environ[key]
+                log.info('"%s" added to env secrets', key)
 
     def connection_string(self) -> str:
         """ Db connection string from Settings """
@@ -233,6 +251,12 @@ def update_db_conf(connection: Connection, items: dict[str, str]) -> dict[str, s
                 session.add(current_conf[key])
 
         session.commit()
+    # Remove from environment variables not in the new brevia_env_secrets
+    if 'brevia_env_secrets' in items:
+        new_secrets = items['brevia_env_secrets']
+        for key in get_settings().brevia_env_secrets:
+            if key not in new_secrets:
+                del environ[key]
     # Clear settings cache, force settings reload
     get_settings.cache_clear()
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,8 +54,7 @@ Brevia supports vistually any LLM provider, each with its own configuration. The
 * to use Anthropic models via API you need a valid API KEY that must be defined in `ANTHROPIC_API_KEY` env var. Have a look at [Anthropic model](models/anthropic.md) for more details.
 * to use DeepSeek models via API you need a valid API KEY that must be defined in `DEEPSEEK_API_KEY` env var. Have a look at [DeepSeek model](models/deepseek.md) for more details.
 
-See [Providers](#providers) paragrah below on available providers, models and related environment variables.
-
+See [Providers](#providers) paragraph below on available providers, models and related environment variables.
 ### LangSmith
 
 If you want to use [LangSmith](https://www.langchain.com/langsmith) to monitor your LLM application with Brevia you need to set these variables:

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,6 +54,8 @@ Brevia supports vistually any LLM provider, each with its own configuration. The
 * to use Anthropic models via API you need a valid API KEY that must be defined in `ANTHROPIC_API_KEY` env var. Have a look at [Anthropic model](models/anthropic.md) for more details.
 * to use DeepSeek models via API you need a valid API KEY that must be defined in `DEEPSEEK_API_KEY` env var. Have a look at [DeepSeek model](models/deepseek.md) for more details.
 
+See [Providers](#providers) paragrah below on available providers, models and related environment variables.
+
 ### LangSmith
 
 If you want to use [LangSmith](https://www.langchain.com/langsmith) to monitor your LLM application with Brevia you need to set these variables:
@@ -225,3 +227,16 @@ A list of supported providers and its models can be defined via `PROVIDERS` vari
 ```
 
 If not set this variable will be automatically populated with the current available providers and models at Brevia startup with the content of [the `/providers` endpoint response](endpoints_overview.md#providers-endpoints).
+
+To help with setup of external providers via UI a `PROVIDERS_ENV_VARS` JSON configuration can be used to list knwon environment variable that con be used for every provider.
+An example of this configuration is:
+
+```JSON
+{
+    "openai": ["OPENAI_API_KEY","OPENAI_ORG_ID","OPENAI_API_BASE"],
+    "anthropic": ["ANTHROPIC_API_KEY"],
+    "cohere": ["COHERE_API_KEY"],
+    "deepseek": ["DEEPSEEK_API_KEY"],
+    "ollama": ["OLLAMA_HOST"]
+}
+```

--- a/docs/endpoints_overview.md
+++ b/docs/endpoints_overview.md
@@ -341,6 +341,19 @@ A small example excerpt could look like this (there are many more items):
     "verbose_mode": true,
     "text_chunk_size": 4555,
     "text_chunk_overlap": 550,
+    "search_docs_num": 7,
+    "qa_completion_llm": {...}
+    ...
+}
+```
+
+Using a `key` query parameter you may filter only specific keys.
+For instance calling `GET /config?key=text_chunk_size&key=search_docs_num` with the configuration above will result in:
+
+```JSON
+{
+    "text_chunk_size": 4555,
+    "search_docs_num": 7
 }
 ```
 
@@ -480,5 +493,44 @@ A small example excerpt could look like this (there are usually many more items)
         ]
     }
 ]
+```
 
+A boolean query parameter `list_models`, with a defaults value `true`, can be used to simply list providers without models.
+Calling `GET /providers?list_models=false` will return as result:
+
+```JSON
+[
+    {
+        "model_provider": "openai"
+    },
+    {
+        "model_provider": "cohere"
+    },
+    {
+        "model_provider": "anthropic"
+    },
+    {
+        "model_provider": "ollama"
+    },
+    {
+        "model_provider": "deepseek"
+    }
+]
+```
+
+### GET `/providers/{provider_name}`
+
+Retrieve a list of all available models for a specific provider.
+
+A small example excerpt could look like this:
+
+```JSON
+{
+    "model_provider": "ollama",
+    "models": [
+        {
+            "name": "llama3.2:latest"
+        }
+    ]
+}
 ```

--- a/docs/endpoints_overview.md
+++ b/docs/endpoints_overview.md
@@ -347,7 +347,7 @@ A small example excerpt could look like this (there are many more items):
 }
 ```
 
-Using a `key` query parameter you may filter only specific keys.
+Using the `key` query parameter you may filter only specific keys.
 For instance calling `GET /config?key=text_chunk_size&key=search_docs_num` with the configuration above will result in:
 
 ```JSON

--- a/tests/routers/test_config_router.py
+++ b/tests/routers/test_config_router.py
@@ -19,6 +19,25 @@ def test_get_config():
     assert response.json() == get_settings().model_dump()
 
 
+def test_get_config_key():
+    """Test /config endpoint with key query parameter"""
+    response = client.get('/config?key=search_docs_num&key=text_chunk_size', headers={})
+    assert response.status_code == 200
+    assert response.json() == {
+        'search_docs_num': get_settings().search_docs_num,
+        'text_chunk_size': get_settings().text_chunk_size,
+    }
+
+
+def test_get_config_key_failure():
+    """Test /config endpoint with key query parameter failure"""
+    response = client.get('/config?key=invalid_key', headers={})
+    assert response.status_code == 400
+    assert response.json() == {
+        'detail': 'There are not configurable settings: invalid_key'
+    }
+
+
 def test_get_config_schema():
     """Test /config/schema endpoint"""
     response = client.get('/config/schema', headers={})

--- a/tests/routers/test_providers_router.py
+++ b/tests/routers/test_providers_router.py
@@ -33,6 +33,7 @@ def test_provider_models(mock_single_provider):
     assert response.json() is not None
     assert response.json() == fake_single
 
+    mock_single_provider.return_value = None
     response = client.get('/providers/unknown_provider')
     assert response.status_code == 404
     assert response.json() is not None

--- a/tests/routers/test_providers_router.py
+++ b/tests/routers/test_providers_router.py
@@ -20,3 +20,20 @@ def test_api_providers(mock_list_providers):
     assert response.json() is not None
     assert isinstance(response.json(), list)
     assert response.json() == fake_list
+
+
+@patch('brevia.routers.providers_router.single_provider')
+def test_provider_models(mock_single_provider):
+    fake_single = {
+        'model_provider': 'mock_provider', 'models': [{'name': 'mock_model'}]
+    }
+    mock_single_provider.return_value = fake_single
+    response = client.get('/providers/mock_provider')
+    assert response.status_code == 200
+    assert response.json() is not None
+    assert response.json() == fake_single
+
+    response = client.get('/providers/unknown_provider')
+    assert response.status_code == 404
+    assert response.json() is not None
+    assert response.json() == {'detail': "Providers 'unknown_provider' not found"}

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -81,6 +81,7 @@ def test_update_providers_exception(mock_list_providers):
 
     assert get_settings().providers == current
 
+
 @patch('brevia.providers.OllamaClient')
 def test_single_provider(mock_ollama):
     """ Test single_provider function """

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -130,10 +130,10 @@ def test_setup_environment():
     """Test setup_environment method"""
     environ.pop('TEST', None)
     current_secrets = get_settings().brevia_env_secrets
-    current_known_vars = get_settings().known_env_vars
+    current_known_vars = get_settings().providers_env_vars
 
     get_settings().brevia_env_secrets = {'BREVIA_TEST1': 'test1'}
-    get_settings().known_env_vars = {'test': ['BREVIA_TEST2']}
+    get_settings().providers_env_vars = {'test': ['BREVIA_TEST2']}
     environ['BREVIA_TEST2'] = 'test2'
 
     get_settings().setup_environment()
@@ -142,4 +142,4 @@ def test_setup_environment():
 
     # Restore previous settings
     get_settings().brevia_env_secrets = current_secrets
-    get_settings().known_env_vars = current_known_vars
+    get_settings().providers_env_vars = current_known_vars

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -138,7 +138,10 @@ def test_setup_environment():
 
     get_settings().setup_environment()
     assert environ.get('BREVIA_TEST1') == 'test1'
-    assert get_settings().brevia_env_secrets == {'BREVIA_TEST1': 'test1', 'BREVIA_TEST2': 'test2'}
+    assert get_settings().brevia_env_secrets == {
+        'BREVIA_TEST1': 'test1',
+        'BREVIA_TEST2': 'test2'
+    }
 
     # Restore previous settings
     get_settings().brevia_env_secrets = current_secrets

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,5 @@
 """Settings module tests"""
+import json
 from os import environ
 import pytest
 from sqlalchemy.orm import Session
@@ -61,6 +62,25 @@ def test_update_db_conf():
     assert conf['search_docs_num'] == '7'
 
 
+def test_update_db_conf_brevia_env():
+    """Test update_db_conf method with brevia_env_secrets"""
+    current = get_settings().brevia_env_secrets
+    get_settings().brevia_env_secrets = {'BREVIA_ENV_SECRET': 'test'}
+    environ['BREVIA_ENV_SECRET'] = 'test'
+
+    new_conf = {'brevia_env_secrets': '{"TEST": "test"}'}
+    conf = update_db_conf(db_connection(), new_conf)
+
+    assert conf['brevia_env_secrets'] == '{"TEST": "test"}'
+    assert environ.get('BREVIA_ENV_SECRET', None) is None
+
+    # update test settings since get_settings.cache_clear() was called
+    conftest.update_settings()
+
+    # Restore previous settings
+    get_settings().brevia_env_secrets = current
+
+
 def test_update_db_conf_failure():
     """Test update_db_conf failure"""
     new_conf = {'search_docs_num': 'wrong value'}
@@ -95,3 +115,31 @@ def test_get_settings_db():
     # restore defaults
     settings.search_docs_num = current_doc_num
     settings.text_chunk_size = current_chunk_size
+
+
+def test_update_brevia_env_secrets():
+    """Test update method on `brevia_env_secrets`"""
+    current = get_settings().brevia_env_secrets
+    get_settings().update({'brevia_env_secrets': json.dumps({'BREVIA_TEST': 'test'})})
+
+    new_secrets = {**current, **{'BREVIA_TEST': 'test'}}
+    assert get_settings().brevia_env_secrets == new_secrets
+
+
+def test_setup_environment():
+    """Test setup_environment method"""
+    environ.pop('TEST', None)
+    current_secrets = get_settings().brevia_env_secrets
+    current_known_vars = get_settings().known_env_vars
+
+    get_settings().brevia_env_secrets = {'BREVIA_TEST1': 'test1'}
+    get_settings().known_env_vars = {'test': ['BREVIA_TEST2']}
+    environ['BREVIA_TEST2'] = 'test2'
+
+    get_settings().setup_environment()
+    assert environ.get('BREVIA_TEST1') == 'test1'
+    assert get_settings().brevia_env_secrets == {'BREVIA_TEST1': 'test1', 'BREVIA_TEST2': 'test2'}
+
+    # Restore previous settings
+    get_settings().brevia_env_secrets = current_secrets
+    get_settings().known_env_vars = current_known_vars


### PR DESCRIPTION
In this PR:

* a new `GET /providers/{provider}` endpoint has been added to retrieve available models of a single providers 
* a boolean `list_models` query parameter, with default value `true`, has been added to optionally list providers without models in `GET /providers` 
* a multiple `key` query parameter in `GET /config` endpoint has been introduced to list only specific configuration keys 
* a new `providers_env_vars` was added. to list of known environment variables for every provider 
* some changes to `brevia_env_secrets` have been introduced:
  - if an environment variablie listed in `providers_env_vars` has been set it will be added to `brevia_env_secrets` if not there already 
  - if an item is removed from `brevia_env_secrets`, its corresponding variable is also removed from the environment 
  - `brevia_env_secrets` contents set via environment is merged with `brevia_env_secrets` content from DB and not simply replaced by the DB content
    