### PR TITLE
Use module relative path for default file prompts

### DIFF
--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -107,7 +107,10 @@ class Settings(BaseSettings):
     summ_token_overlap: int = 500
 
     # Prompt files base path - local or shared file system
-    prompts_base_path: str = Field(default=f'{path.dirname(__file__)}/prompts', exclude=True)
+    prompts_base_path: str = Field(
+        default=f'{path.dirname(__file__)}/prompts',
+        exclude=True,
+    )
 
     # Providers: list of available providers and models
     providers: Json = '[]'

--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -1,7 +1,7 @@
 """Settings module"""
 import logging
 from functools import lru_cache
-from posixpath import dirname
+from os.path import dirname
 from typing import Annotated, Any
 from os import environ
 from urllib import parse

--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -1,9 +1,8 @@
 """Settings module"""
 import logging
 from functools import lru_cache
-from os.path import dirname
 from typing import Annotated, Any
-from os import environ
+from os import environ, path
 from urllib import parse
 from sqlalchemy import NullPool, create_engine, Column, String, func, inspect
 from sqlalchemy.engine import Connection
@@ -108,7 +107,7 @@ class Settings(BaseSettings):
     summ_token_overlap: int = 500
 
     # Prompt files base path - local or shared file system
-    prompts_base_path: str = Field(default=f'{dirname(__file__)}/prompts', exclude=True)
+    prompts_base_path: str = Field(default=f'{path.dirname(__file__)}/prompts', exclude=True)
 
     # Providers: list of available providers and models
     providers: Json = '[]'

--- a/brevia/settings.py
+++ b/brevia/settings.py
@@ -1,8 +1,9 @@
 """Settings module"""
 import logging
 from functools import lru_cache
+from posixpath import dirname
 from typing import Annotated, Any
-from os import environ, getcwd
+from os import environ
 from urllib import parse
 from sqlalchemy import NullPool, create_engine, Column, String, func, inspect
 from sqlalchemy.engine import Connection
@@ -107,7 +108,7 @@ class Settings(BaseSettings):
     summ_token_overlap: int = 500
 
     # Prompt files base path - local or shared file system
-    prompts_base_path: str = Field(default=f'{getcwd()}/brevia/prompts', exclude=True)
+    prompts_base_path: str = Field(default=f'{dirname(__file__)}/prompts', exclude=True)
 
     # Providers: list of available providers and models
     providers: Json = '[]'


### PR DESCRIPTION
This PR updates the settings module to use a module relative path for locating prompt files rather than relying on the current working directory, otherwise we get `FileNotFoundError` using `brevia` library without setting a prompts base path.
