### PR TITLE
Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gh-actions:
+        patterns: ['actions/*']
+      bedita:
+        patterns: ['bedita/*']
+      colathro:
+        patterns: ['colathro/*']
+      coverallsapp:
+        patterns: ['coverallsapp/*']
+      docker:
+        patterns: ['docker/*']
+      jrubics:
+        patterns: ['JRubics/*']
+      snok:
+        patterns: ['snok/*']


### PR DESCRIPTION
This introduces dependabot configuration to enable auto-check (an open PRs) on used github actions version updates.